### PR TITLE
Remove bad style rules, so iframe will not be cut-off in MFE

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
@@ -26,15 +26,6 @@ h1, h2, h3, h1 span, h2 span, h3 span, .nav-item {
   font-family: $font-family-title;
 }
 
-#content.content-wrapper {
-  @include media-breakpoint-up(lg) {
-    padding-top: $content-padding-top;
-    padding-bottom: $content-padding-bottom;
-    margin-top: $header-height;
-  }
-  min-height: calc(100vh - #{$header-height + $content-padding-top + $content-padding-bottom + $footer-height}); // sticky footer
-}
-
 ////////////////// Fonts
 @import "fonts";
 


### PR DESCRIPTION
In the MFE, the `#content.content-wrapper` style rule in `_extra.scss` pushes the iframe contents down (lots of white space), and besides cuts off the bottom of the iframe, and this without obtaining a "sticky footer" like the comment says. The online Tutor demo (also using Indigo theme) doesn't have this rule, and shows the frontend perfectly, so it looks like this rule should be removed completely.