### PR TITLE
make lms .content-wrapper style rule more specific

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
@@ -26,7 +26,9 @@ h1, h2, h3, h1 span, h2 span, h3 span, .nav-item {
   font-family: $font-family-title;
 }
 
-header.global-header ~ #content.content-wrapper {
+// It is necessary to specify `:not(.courseware) >` in order to not affect the style
+// of `#content.content-wrapper` inside the unit iframe in the MFE
+:not(.courseware) > #content.content-wrapper {
   @include media-breakpoint-up(lg) {
     padding-top: $content-padding-top;
     padding-bottom: $content-padding-bottom;

--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
@@ -26,7 +26,7 @@ h1, h2, h3, h1 span, h2 span, h3 span, .nav-item {
   font-family: $font-family-title;
 }
 
-#content.content-wrapper {
+header.global-header ~ #content.content-wrapper {
   @include media-breakpoint-up(lg) {
     padding-top: $content-padding-top;
     padding-bottom: $content-padding-bottom;


### PR DESCRIPTION
The `#content.content-wrapper` style rule in `_extra.scss` is not specific enough, without this patch it will also affect course content inside MFE (inside the wrapping iframe), and couse a lot of extra white space and cut-off:

![img_1](https://user-images.githubusercontent.com/3638794/170133269-7d1edf65-e581-4b3a-9790-1c5934580364.png)

![img_2](https://user-images.githubusercontent.com/3638794/170133300-086ab9b8-0538-4d34-9cdf-0c1a74998723.png)

This patch only applies the style rules for `#content.content-wrapper` (in essence pushing this block down in case of a fixed header), if it follows a global header `header.global-header`, hence will not affect the html inside the MFE iframe.