### PR TITLE
fix: actually render scss files in tutor env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-render:
-	tutor config render --extra-config ./config.yml ./theme "$$(tutor config printroot)/env/build/openedx/themes/indigo"
-
-watch: render
-	while true; do inotifywait -e modify --recursive config.yml ./theme; $(MAKE) render; done

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.7",
-    install_requires=["tutor>=13.2.0,<14.0.0"],
+    install_requires=["tutor>=13.2.4,<14.0.0"],
     entry_points={"tutor.plugin.v1": ["indigo = tutorindigo.plugin"]},
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -1,5 +1,3 @@
-from glob import glob
-import os
 import pkg_resources
 
 from tutor import hooks
@@ -43,6 +41,9 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
         ("indigo", "build/openedx/themes"),
     ],
 )
+
+# Force the rendering of scss files, even though they are included in a "partials" directory
+hooks.Filters.ENV_PATTERNS_INCLUDE.add_item(r"indigo/lms/static/sass/partials/lms/theme/")
 
 # Load all configuration entries
 hooks.Filters.CONFIG_DEFAULTS.add_items(


### PR DESCRIPTION
*.scss files were not rendered at all in the tutor environment because they are
stored in a "partials" subdirectory.

Here, we make use of the new pattern include/ignore filter to force the
rendering of the indigo theme directory.

Close #24.
