### PR TITLE
Add step to save configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Since Tutor v13.2.0, Indigo can be installed as a Tutor plugin::
 
     pip install tutor-indigo
     tutor plugins enable indigo
+    tutor config save
 
 Rebuild the Openedx docker image::
 


### PR DESCRIPTION
Adding the step `tutor config save` as this is what puts the indigo folder into the build environment.