### PR TITLE
There is already an <h1> on the pages

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/index_overlay.html
+++ b/tutorindigo/templates/indigo/lms/templates/index_overlay.html
@@ -1,2 +1,2 @@
-<h1>${settings.PLATFORM_NAME}</h1>
+<h2>${settings.PLATFORM_NAME}</h2>
 <p>{{ INDIGO_WELCOME_MESSAGE }}</p>

--- a/tutorindigo/templates/indigo/lms/templates/static_templates/about.html
+++ b/tutorindigo/templates/indigo/lms/templates/static_templates/about.html
@@ -6,9 +6,9 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>
+        <h2>
             <%block name="pageheader">${page_header or _("About")}</%block>
-        </h1>
+        </h2>
         <p>
             <%block name="pagecontent">{{ PLATFORM_NAME }} is an online learning platform powered by <a href="https://open.edx.org">Open edX</a>. It runs with <a href="https://docs.tutor.overhang.io">Tutor</a>, with the customized <a href="https://github.com/overhangio/tutor-indigo">Indigo</a> theme.</%block>
         </p>

--- a/tutorindigo/templates/indigo/lms/templates/static_templates/contact.html
+++ b/tutorindigo/templates/indigo/lms/templates/static_templates/contact.html
@@ -6,9 +6,9 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>
+        <h2>
             <%block name="pageheader">${page_header or _("Contact")}</%block>
-        </h1>
+        </h2>
         <p>
             <%block name="pagecontent">For any question regarding the usage of {{ PLATFORM_NAME }}, please get in touch with <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a>.</%block>
         </p>

--- a/tutorindigo/templates/indigo/lms/templates/static_templates/tos.html
+++ b/tutorindigo/templates/indigo/lms/templates/static_templates/tos.html
@@ -6,9 +6,9 @@
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="container about">
-        <h1>
+        <h2>
             <%block name="pageheader">${page_header or _("Terms of Service")}</%block>
-        </h1>
+        </h2>
         <p>
             <%block name="pagecontent">The terms of service of {{ PLATFORM_NAME }} can be obtained by getting in touch with our support at <a href="mailto:{{ CONTACT_EMAIL }}">{{ CONTACT_EMAIL }}</a>.</%block>
         </p>


### PR DESCRIPTION
There is already an `<h1>` in the template being rendered. There should only be one `<h1>` on a webpage with `<h1 class="header-logo">`