### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,14 +6,14 @@ Indigo is an elegant, customizable theme for `Open edX <https://open.edx.org>`__
 .. image:: ./screenshots/01-landing-page.png
     :alt: Platform landing page
 
-**Note**: This version of the Indigo theme is compatible with the Maple release of Open edX.
+**Note**: This version of the Indigo theme is compatible with the Nutmeg release of Open edX.
 
 You can view the theme in action at https://demo.openedx.overhang.io.
 
 Installation
 ------------
 
-Indigo was specially developed to be used with `Tutor <https://docs.overhang.io>`__ (at least v12.0.0). If you have not installed Open edX with Tutor, then installation instructions will vary.
+Indigo was specially developed to be used with `Tutor <https://docs.overhang.io>`__ (at least v14.0.0). If you have not installed Open edX with Tutor, then installation instructions will vary.
 
 Since Tutor v13.2.0, Indigo can be installed as a Tutor plugin::
 


### PR DESCRIPTION
Unable to install indigo theme with Tutor v13.2.0 since setup.py updated to v14.0.0.

You can see the line from the following link:
https://github.com/overhangio/tutor-indigo/blob/3fd43d00bece14365cd8aaa4853367f26060d9a5/setup.py#L43