### PR TITLE
docs: recommend nested quotes for setting primary color

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,11 @@ The ``INDIGO_*`` settings listed above may be modified by running ``tutor config
 
     tutor config save --set "INDIGO_FOOTER_NAV_LINKS=[]" --set "INDIGO_FOOTER_LEGAL_LINKS=[]"
 
+Or, to set the primary color to forest green, run::
+
+    # Note: The nested quotes are needed in order to handle the hash (#) correctly.
+    tutor config save --set 'INDIGO_PRIMARY_COLOR="#225522"'
+
 Customization
 -------------
 


### PR DESCRIPTION
In Tutor 16.0.2 in zsh, this command:

    tutor config save --set "INDIGO_PRIMARY_COLOR=#225522"

will set `INDIGO_PRIMARY_COLOR` to `null` in config.yml. The same is true if double-quotes are used. If one wraps the color in additional set of quotes, though, then `INDIGO_PRIMARY_COLOR` is set without any issues.

I believe this is due to how the `#` is handled when rendering config.yml, but I haven't been able to dig into Tutor and confirm that. For now, I propose adding this example to this README in hope that it'll stop anyone from getting stuck on the `#` issue.