### PR TITLE
fix: CMS render scss styling in tutor env 

### DIFF
--- a/changelog.d/20240220_174954_talharizwan667_indigo_cms_scss.md
+++ b/changelog.d/20240220_174954_talharizwan667_indigo_cms_scss.md
@@ -1,0 +1,1 @@
+- [Bugfix] *.scss files in cms directory were not rendered in the tutor environment because they are stored in a "partials" subdirectory. (by @Talha-Rizwan)

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -57,9 +57,13 @@ hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
 )
 
 # Force the rendering of scss files, even though they are included in a "partials" directory
-hooks.Filters.ENV_PATTERNS_INCLUDE.add_item(
-    r"indigo/lms/static/sass/partials/lms/theme/"
+hooks.Filters.ENV_PATTERNS_INCLUDE.add_items(
+    [
+        r"indigo/lms/static/sass/partials/lms/theme/",
+        r"indigo/cms/static/sass/partials/cms/theme/",
+    ]
 )
+
 
 # init script: set theme automatically
 with open(


### PR DESCRIPTION
-  *.scss files in cms were not rendered at all in the tutor environment because they are stored in a "partials" subdirectory.
-  added override styling for cms using _variables.scss and _extras.scss
- added a customizable footer with styling as no custom footer was there for cms but for lms.

PR for #69 
