### PR TITLE
Remove mentions of INDIGO_FOOTER_LEGAL_LINKS from documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,10 @@ Configuration
 - ``INDIGO_WELCOME_MESSAGE`` (default: "The place for all your online learning")
 - ``INDIGO_PRIMARY_COLOR`` (default: "#3b85ff")
 - ``INDIGO_FOOTER_NAV_LINKS`` (default: ``[{"title": "About", "url": "/about"}, {"title": "Contact", "url": "/contact"}]``)
-- ``INDIGO_FOOTER_LEGAL_LINKS`` (default: ``[{"title": "Terms of service", "url": "/tos"}, {"title": "Indigo theme for Open edX", "url": "https://github.com/overhangio/tutor-indigo"}]``)
 
 The ``INDIGO_*`` settings listed above may be modified by running ``tutor config save --set INDIGO_...=...``. For instance, to remove all links from the footer, run::
 
-    tutor config save --set "INDIGO_FOOTER_NAV_LINKS=[]" --set "INDIGO_FOOTER_LEGAL_LINKS=[]"
+    tutor config save --set "INDIGO_FOOTER_NAV_LINKS=[]"
 
 Or, to set the primary color to forest green, run::
 

--- a/changelog.d/20240220_091010_misilot_remove_legal_links_mentions.md
+++ b/changelog.d/20240220_091010_misilot_remove_legal_links_mentions.md
@@ -1,0 +1,13 @@
+
+<!--
+Create a changelog entry for every new user-facing change. Please respect the following instructions:
+- Indicate breaking changes by prepending an explosion 💥 character.
+- Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+- You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+the release notes for every release.
+-->
+
+<!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+<!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+- [Improvement] Remove mentions of INDIGO_FOOTER_LEGAL_LINKS in docs since it is no longer used by the plugin. (by @misilot)

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -23,7 +23,7 @@ config: t.Dict[str, t.Dict[str, t.Any]] = {
         "PRIMARY_COLOR": "#3b85ff",  # cool blue
         # Footer links are dictionaries with a "title" and "url"
         # To remove all links, run:
-        # tutor config save --set INDIGO_FOOTER_NAV_LINKS=[] --set INDIGO_FOOTER_LEGAL_LINKS=[]
+        # tutor config save --set INDIGO_FOOTER_NAV_LINKS=[]
         "FOOTER_NAV_LINKS": [
             {"title": "About Us", "url": "/about"},
             {"title": "Blog", "url": "/blog"},
@@ -32,13 +32,6 @@ config: t.Dict[str, t.Dict[str, t.Any]] = {
             {"title": "Privacy Policy", "url": "/privacy"},
             {"title": "Help", "url": "/help"},
             {"title": "Contact Us", "url": "/contact"},
-        ],
-        "FOOTER_LEGAL_LINKS": [
-            {"title": "Terms of service", "url": "/tos"},
-            {
-                "title": "Indigo theme for Open edX",
-                "url": "https://github.com/overhangio/tutor-indigo",
-            },
         ],
     },
     "unique": {},


### PR DESCRIPTION
It looks like INDIGO_FOOTER_NAV_LINKS is no longer used, so cleaning up the documentation
