### PR TITLE
fix: add fallback image for course detail page

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/courseware/course_about.html
+++ b/tutorindigo/templates/indigo/lms/templates/courseware/course_about.html
@@ -71,7 +71,7 @@ from openedx.core.lib.courses import course_image_url
         %else:
         <div class="media">
           <div class="hero">
-            <img src="${course_image_urls['large']}" alt="" />
+            <img src="${course_image_urls['large']}" onerror="this.src='/theming/asset/images/no_course_image.png';" alt="" />
           </div>
         </div>
         % endif


### PR DESCRIPTION
In case of no course image, course about page should show fallback course image