### PR TITLE
fix: ugettext deprecated

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ For instance, edit the "donate.html" file in this directory. We can derive the c
 .. code-block:: mako
 
     <%page expression_filter="h"/>
-    <%! from django.utils.translation import ugettext as _ %>
+    <%! from django.utils.translation import gettext as _ %>
     <%inherit file="../main.html" />
 
     <%block name="pagetitle">${_("Donate")}</%block>


### PR DESCRIPTION
Calling any of ugettext(), ugettext_lazy(), ugettext_noop(), ungettext() and ungettext_lazy() functions from django.utils.translation will raise an error in django 4+.