### PR TITLE
fix: problem displaying /account/ page after upgraded to redwood

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -104,6 +104,8 @@ hooks.Filters.CONFIG_OVERRIDES.add_items(list(config["overrides"].items()))
 
 hooks.Filters.ENV_PATCHES.add_items(
     [
+        # MFE will install header version 3.0.x and will include indigo-footer as a
+        # separate package for use in env.config.jsx
         (
             "mfe-dockerfile-post-npm-install-learning",
             """

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -47,6 +47,7 @@ hooks.Filters.ENV_TEMPLATE_ROOTS.add_item(
 hooks.Filters.ENV_TEMPLATE_TARGETS.add_items(
     [
         ("indigo", "build/openedx/themes"),
+        ("indigo/env.config.jsx", "plugins/mfe/build/mfe"),
     ],
 )
 
@@ -107,7 +108,7 @@ hooks.Filters.ENV_PATCHES.add_items(
             "mfe-dockerfile-post-npm-install-learning",
             """
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIGO_ENABLE_DARK_THEME %} --theme=dark{% endif %}
-RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.0.0'
+RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@~3.0.0'
 RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
 
 COPY indigo/env.config.jsx /openedx/app/
@@ -125,7 +126,7 @@ RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIG
             "mfe-dockerfile-post-npm-install-discussions",
             """
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIGO_ENABLE_DARK_THEME %} --theme=dark{% endif %}
-RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.0.0'
+RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@~3.0.0'
 RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
 
 COPY indigo/env.config.jsx /openedx/app/
@@ -144,7 +145,7 @@ COPY indigo/env.config.jsx /openedx/app/
             "mfe-dockerfile-post-npm-install-profile",
             """
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIGO_ENABLE_DARK_THEME %} --theme=dark{% endif %}
-RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.0.0'
+RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@~3.0.0'
 RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
 
 COPY indigo/env.config.jsx /openedx/app/
@@ -154,7 +155,7 @@ COPY indigo/env.config.jsx /openedx/app/
             "mfe-dockerfile-post-npm-install-account",
             """
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIGO_ENABLE_DARK_THEME %} --theme=dark{% endif %}
-RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.0.0'
+RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@~3.0.0'
 RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
 
 COPY indigo/env.config.jsx /openedx/app/

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -108,7 +108,9 @@ hooks.Filters.ENV_PATCHES.add_items(
             """
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIGO_ENABLE_DARK_THEME %} --theme=dark{% endif %}
 RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.0.0'
-RUN npm install '@edx/frontend-component-footer@npm:@edly-io/indigo-frontend-component-footer@^2.0.0'
+RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
+
+COPY indigo/env.config.jsx /openedx/app/
 """,
         ),
         (
@@ -124,14 +126,18 @@ RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIG
             """
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIGO_ENABLE_DARK_THEME %} --theme=dark{% endif %}
 RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.0.0'
-RUN npm install '@edx/frontend-component-footer@npm:@edly-io/indigo-frontend-component-footer@^2.0.0'
+RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
+
+COPY indigo/env.config.jsx /openedx/app/
 """,
         ),
         (
             "mfe-dockerfile-post-npm-install-learner-dashboard",
             """
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIGO_ENABLE_DARK_THEME %} --theme=dark{% endif %}
-RUN npm install '@edx/frontend-component-footer@npm:@edly-io/indigo-frontend-component-footer@^2.0.0'
+RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
+
+COPY indigo/env.config.jsx /openedx/app/
 """,
         ),
         (
@@ -139,8 +145,9 @@ RUN npm install '@edx/frontend-component-footer@npm:@edly-io/indigo-frontend-com
             """
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIGO_ENABLE_DARK_THEME %} --theme=dark{% endif %}
 RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.0.0'
-RUN npm install '@edx/frontend-component-footer@npm:@edly-io/indigo-frontend-component-footer@^2.0.0'
+RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
 
+COPY indigo/env.config.jsx /openedx/app/
 """,
         ),
         (
@@ -148,7 +155,9 @@ RUN npm install '@edx/frontend-component-footer@npm:@edly-io/indigo-frontend-com
             """
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.0.0'{% if INDIGO_ENABLE_DARK_THEME %} --theme=dark{% endif %}
 RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.0.0'
-RUN npm install '@edx/frontend-component-footer@npm:@edly-io/indigo-frontend-component-footer@^2.0.0'
+RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
+
+COPY indigo/env.config.jsx /openedx/app/
 """,
         ),
     ]

--- a/tutorindigo/templates/indigo/env.config.jsx
+++ b/tutorindigo/templates/indigo/env.config.jsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react';
+
+import Footer from '@edly-io/indigo-frontend-component-footer';
+import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
+
+const themePluginSlot = {
+  keepDefault: false,
+  plugins: [
+    {
+      op: PLUGIN_OPERATIONS.Insert,
+      widget: {
+        id: 'default_contents',
+        type: DIRECT_PLUGIN,
+        priority: 1,
+        RenderWidget: <Footer />,
+      },
+    }
+  ],
+};
+
+const config = {
+  pluginSlots: {
+    footer_slot: themePluginSlot,
+  },
+};
+
+export default config;

--- a/tutorindigo/templates/indigo/env.config.jsx
+++ b/tutorindigo/templates/indigo/env.config.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import Footer from '@edly-io/indigo-frontend-component-footer';
 import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';


### PR DESCRIPTION
Issue:
With Tutor v18 and Tutor Indigo v18.1.0, users are unable to view the accounts page. Tutor Indigo v18.1.0 has installation of custom indigo header and footer in learning, dashboard, profile, discussion and account MFE. All MFEs are compatible with indigo header and footer except accounts MFE. The reason is:

In redwood:
**Most of the MFEs using  ----> footer v14**
- footer is installed via `@openedx/frontend-slot-footer package`
- footer is imported like `import FooterSlot from '@openedx/frontend-slot-footer'`;

**Account MFE -----> footer v13**
- footer is installed via `@edx/frontend-component-footer`
- footer is imported like `import { FooterSlot } from '@edx/frontend-component-footer';`

Our indigo footer is created from footer v14 and we are installing it in all MFEs (account MFE has footer v13). More details can be found on [this issue](https://github.com/openedx/frontend-app-account/issues/1071) 

Solves https://github.com/overhangio/tutor/issues/1111