### PR TITLE
fix: fix various dark theme issues with Teams tab

### DIFF
--- a/changelog.d/20241206_184802_dawoud.sheraz_teams_tab_dark_theme_fixups.md
+++ b/changelog.d/20241206_184802_dawoud.sheraz_teams_tab_dark_theme_fixups.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fix various dark theme issues with Teams tab on LMS. (by @dawoudsheraz)

--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
@@ -1336,6 +1336,7 @@ body.indigo-dark-theme {
     }
     .page-content-nav .nav-item {
       color: $text-color-d;
+      &.is-active{ border-color: $primary-d; }
     }
     .page-content-main {
       span.listing-count, span.listing-sort .field-label {
@@ -1364,6 +1365,53 @@ body.indigo-dark-theme {
       .team-required-fields .u-field-title, .team-optional-fields .u-field-title{
         color: $text-color-d;
       }
+    }
+
+    .listing-tools{ color: $text-color-d; }
+    .u-field-message {
+      .u-field-message-help, .u-field-message-notification{
+        color: grey;
+      }
+    }
+    .team-profile{
+      .page-content-secondary{
+        color: grey;
+      }
+    } 
+
+    .card {
+      .card-type, .card-description{
+        color: grey;
+      }
+
+      .wrapper-card-meta{
+        background: $primary-light-d;
+        .meta-detail{ color: $text-color-primary; }
+      } 
+      
+      .card-actions .action-view{
+        border-color: $primary-d;
+        color: $primary-d;
+        &:hover{
+          background-color: $primary-d;
+          color: $primary-light-d;
+        }
+      }
+    }
+
+    .btn-secondary,.btn-link,
+    .edit-members .action-remove-member {
+      color: $primary-d;
+    }
+
+    .action-primary{
+      background: $primary-d;
+      color: $primary-light-d;
+    }
+
+    .teams-content #teams-message.wrapper-msg{
+      background: $primary-light-d;
+      div.msg{ color: $text-color-d; }
     }
   }
 }

--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
@@ -1325,6 +1325,47 @@ body.indigo-dark-theme {
       font-weight: 500;
     }
   } 
+  &.view-teams {
+    .page-header {
+      .page-title {
+        color: $text-color-primary;
+      }
+      .page-description {
+        color: $text-color-d;
+      }
+    }
+    .page-content-nav .nav-item {
+      color: $text-color-d;
+    }
+    .page-content-main {
+      span.listing-count, span.listing-sort .field-label {
+        color: $text-color-d;
+      }
+    }
+
+    ul.topics-list li.topic-card{
+      background-color: $body-bg-d;
+
+      div.wrapper-card-meta {
+        background-color: $body-bg-d;
+      }
+
+    }
+
+    ul.cards-list li.list-card {
+      background-color: $body-bg-d;
+
+      div.wrapper-card-meta {
+        background-color: $body-bg-d;
+      }
+    }
+
+    .teams-content .teams-main .team-edit-fields {
+      .team-required-fields .u-field-title, .team-optional-fields .u-field-title{
+        color: $text-color-d;
+      }
+    }
+  }
 }
 @import '../../../extra/footer';
 @import '../../../extra/header';


### PR DESCRIPTION
Resolve a part of https://github.com/overhangio/tutor-indigo/issues/107 and https://github.com/openedx/wg-build-test-release/issues/410 -- fixes dark theme compatibility issues with Teams tab

<img width="1673" alt="Screenshot 2024-12-06 at 6 33 23 PM" src="https://github.com/user-attachments/assets/f9d8897d-6140-4f57-b49e-fc3e7a3322ac">
<img width="1673" alt="Screenshot 2024-12-06 at 6 33 31 PM" src="https://github.com/user-attachments/assets/4e2fd89f-3cf0-4763-82c5-58895f4e9f6c">
<img width="1673" alt="Screenshot 2024-12-06 at 6 33 44 PM" src="https://github.com/user-attachments/assets/ede7d3d4-9b0f-4c8d-9d5a-3cf5ce822fc6">
<img width="1673" alt="Screenshot 2024-12-06 at 6 34 00 PM" src="https://github.com/user-attachments/assets/fe2b2326-e924-4a94-b954-21cb75fe2125">
<img width="1673" alt="Screenshot 2024-12-06 at 6 40 38 PM" src="https://github.com/user-attachments/assets/9f9724a3-725c-44f9-878a-cf6205cd0ee0">
<img width="1673" alt="Screenshot 2024-12-06 at 6 41 42 PM" src="https://github.com/user-attachments/assets/9348b135-2553-4f03-b98f-57d1ea0f7134">
