### PR TITLE
fix: add dark-theme to notes and textbook page

### DIFF
--- a/changelog.d/20241209_134456_hina.khadim_teams_notes_page.md
+++ b/changelog.d/20241209_134456_hina.khadim_teams_notes_page.md
@@ -1,1 +1,1 @@
-- [BugFix] Update dark-theme styles for Notes and Textbook Page (by @hinakhadim)
+- [Bugfix] Update dark-theme styles for Notes and Textbook Page (by @hinakhadim)

--- a/changelog.d/20241209_134456_hina.khadim_teams_notes_page.md
+++ b/changelog.d/20241209_134456_hina.khadim_teams_notes_page.md
@@ -1,0 +1,1 @@
+- [BugFix] Update dark-theme styles for Notes and Textbook Page (by @hinakhadim)

--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
@@ -298,33 +298,35 @@ nav.wrapper-preview-menu {
     }
   }
 }
-body.view-statictab, body.view-instructordash, body.view-teams, body.view-wiki {
-  .wrapper-course-material {
-    margin: 0 auto;
-    max-width: 1600px;
-    padding: 20px 15px !important;
-    .tabs.course-tabs {
-      margin: 0 0 10px;
-      border-bottom: 1px solid #E5E7EB;
-      li {
-        margin: 0 32px 0 0;
-        a {
-          border-width: 2px;
-          font-size: 14px;
-          font-weight: 500;
-          color: $light-dark;
-          &:hover, &:visited {
-            color: $dark;
-            border-color: transparent;
-          }
-          &.active {
-            color: $dark;
-            border-color: $primary;
-          }
+.wrapper-course-material[aria-label="Course Material"] {
+  margin: 0 auto;
+  max-width: 1600px;
+  padding: 20px 15px !important;
+  .tabs.course-tabs {
+    margin: 0 0 10px;
+    border-bottom: 1px solid #E5E7EB;
+    padding: 0;
+    li {
+      margin: 0 32px 0 0;
+      a {
+        border-width: 2px;
+        font-size: 14px;
+        font-weight: 500;
+        color: $light-dark;
+        &:hover, &:visited {
+          color: $dark;
+          border-color: transparent;
+        }
+        &.active {
+          color: $dark;
+          border-color: $primary;
         }
       }
     }
   }
+}
+body.view-statictab, body.view-instructordash, body.view-teams, body.view-wiki,
+body.view-student-notes {
   #main {
     .container {
       padding: 0;
@@ -764,6 +766,12 @@ body.view-wiki{
     }
   }
 }
+// Textbook Page
+body div.book-wrapper{
+  margin: 0 auto;
+  max-width: 1600px;
+}
+
 body.indigo-dark-theme {
   input:-webkit-autofill,
   input:-webkit-autofill:hover, 
@@ -797,31 +805,33 @@ body.indigo-dark-theme {
   .idash-section .no-pending-tasks-message p {
     color: $text-color-d;
   }
-  &.view-statictab, &.view-instructordash, &.view-teams, &.view-wiki {
+  .wrapper-course-material {
+    .tabs.course-tabs {
+      border-bottom: 1px solid $primary-light-d;
+      li {
+        a {
+          color: $text-color-d;
+          &:hover, &:visited {
+            color: $text-color-primary;
+            border-color: transparent;
+          }
+          &.active {
+            color: $text-color-d;
+            border-color: $text-color-d;
+          }
+        }
+      }
+    }
+  }
+  &.view-statictab, &.view-instructordash, &.view-teams, &.view-wiki,
+  &.view-student-notes {
     .window-wrap {
       background: none;
     }
     #email-students-beta-tip {
       color: #111827;
     }
-    .wrapper-course-material {
-      .tabs.course-tabs {
-        border-bottom: 1px solid $primary-light-d;
-        li {
-          a {
-            color: $text-color-d;
-            &:hover, &:visited {
-              color: $text-color-primary;
-              border-color: transparent;
-            }
-            &.active {
-              color: $text-color-d;
-              border-color: $text-color-d;
-            }
-          }
-        }
-      }
-    }
+
     .instructor-dashboard-content-2 {
       a.instructor-info-action {
         background: $primary-d;
@@ -1414,6 +1424,49 @@ body.indigo-dark-theme {
       div.msg{ color: $text-color-d; }
     }
   }
+
+  // Textbook Page
+  .book-wrapper{
+      .book-sidebar{
+          background: $primary-light-d;
+          #booknav a{
+              color: $text-color-d;
+              &:hover{
+                  color: $text-color-primary;
+              }
+          }
+      }
+  }
+
+  // Notes Page
+  &.view-student-notes{
+    .wrapper-student-notes{
+      background: $body-bg-d;
+    }
+
+    .wrapper-title .page-title .page-subtitle{
+      color: $text-color-d;
+    }
+
+    .wrapper-tabs .tab-list{
+      .tabs-label{
+        color: grey;
+      }
+
+      .tab.is-active .tab-label{
+        color: $text-color-d;
+        border-bottom-color: $text-color-primary;
+      }
+    } 
+
+    .placeholder{ 
+      border-color: $primary-d; 
+      background: $primary-light-d;
+
+      .placeholder-title{ color: $text-color-d; }
+    }
+  } 
+
 }
 @import '../../../extra/footer';
 @import '../../../extra/header';

--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
@@ -1449,21 +1449,78 @@ body.indigo-dark-theme {
     }
 
     .wrapper-tabs .tab-list{
-      .tabs-label{
-        color: grey;
+      .tab .tab-label{
+        color: lightgrey;
       }
 
-      .tab.is-active .tab-label{
-        color: $text-color-d;
-        border-bottom-color: $text-color-primary;
+      .tab.is-active{ 
+        .tab-label{
+          color: $text-color-d;
+          border-bottom-color: $text-color-primary;
+        }
+      }
+
+      #view-search-results .action-close{
+        color: $primary-d;
+        background: $body-bg-d;
+        border-color: transparent;
+        box-shadow: none;
       }
     } 
+
+    .listing-tools{ color: lightgrey; }
 
     .placeholder{ 
       border-color: $primary-d; 
       background: $primary-light-d;
 
       .placeholder-title{ color: $text-color-d; }
+    }
+
+    .wrapper-notes-search{
+      .search-notes-input{
+        background: $primary-light-d;
+        color: $text-color-d;
+        border: 1px solid grey;
+      }
+      .search-notes-submit{
+        background: $primary-d;
+        border-color: $primary-d;
+      }
+    }
+
+    .ui-loading{
+      border-color: $primary-d;
+      background: $body-bg-d;
+    }
+
+    .tab-panel.note-group{
+      .note{
+        .wrapper-note-excerpts{
+          border-color: orange;
+          .note-excerpt{
+            background: orange;
+            color: $body-bg-d;
+          }
+
+          .note-comments .note-comment-p{ color: $text-color-d; }
+        }
+        &:hover{ 
+          .note-excerpt{
+            background: $danger-d;
+          }
+        }
+
+        footer.reference .wrapper-reference-content{
+          a.reference-meta{
+            color: $primary-d; 
+          }
+          .reference-meta{ 
+            color: $text-color-d; 
+            &::after{ color: $text-color-primary; }
+          }
+        }
+      }
     }
   } 
 

--- a/tutorindigo/templates/indigo/lms/static/sass/xblock/_xblock.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/xblock/_xblock.scss
@@ -463,4 +463,87 @@
         }
 
     }
+
+    .edx-notes-wrapper{
+        .annotator-hl{
+            background: orange;
+            color: $primary-light-d;
+        }
+
+        .annotator-outer.annotator-viewer{
+            div:first-of-type{
+                color: $text-color-d;
+            }
+
+            .annotator-annotation.annotator-item{
+                background: $body-bg-d;
+
+                .annotator-note{
+                    color: $text-color-d !important;
+                }
+
+                .annotator-tags{
+                    border-color: $primary-light-d;
+                    .annotator-tag{
+                        background: lightgrey;
+                        color: $primary-light-d;
+                        
+                    }
+                } 
+            }
+
+            .annotator-controls {
+                .annotator-close::before,
+                .annotator-edit::before,
+                .annotator-delete::before{
+                    color: $primary-d;
+                }
+            }
+        }
+
+        .annotator-adder{
+            button{
+                background: $primary-light-d !important;
+                &::after{ 
+                    color: $primary-d;
+                    text-shadow: none;
+                }
+                &::before{ background: $primary-light-d;}
+            }
+        }
+
+        .annotator-outer.annotator-editor{
+            .annotator-widget{
+                background: $body-bg-d !important;
+            }
+            .annotator-listing{
+                background: $body-bg-d;
+                .annotator-item{
+                    border-top: 1px solid grey;
+                    &:first-child textarea{
+                        background: $light-overlay-d !important;
+                        color: $text-color-d !important;
+                    }
+                    input{
+                        background: $light-overlay-d;
+                        color: $text-color-d;
+                    }
+                }
+            }
+            .annotator-controls{
+                background: $primary-light-d !important;
+                box-shadow: none;
+                .annotator-save{
+                    background: $primary-d;
+                    color: $primary-light-d;
+                    &:hover{
+                        color: $primary-light-d;
+                    }
+                }
+                .annotator-cancel{
+                    color: $primary-d;
+                }
+            }
+        }  
+    }
 }


### PR DESCRIPTION
This PR adds dark-theme to notes and textbook page
## Before
### 1.Notes Page
<img width="1702" alt="image" src="https://github.com/user-attachments/assets/8c2a3c0e-3438-4c44-a477-4678d44c2e61">


### 2.Textbook Page
<img width="1702" alt="image" src="https://github.com/user-attachments/assets/d687e386-fd82-43b5-a418-f77f6e816c7a">



## After
### 1.Notes Page
<img width="1702" alt="image" src="https://github.com/user-attachments/assets/ccbde9ee-13a3-4c65-af16-6f194f20d66d">
-----------------------------------------------------------------------------------------------
<img width="1702" alt="image" src="https://github.com/user-attachments/assets/31e11fa2-056c-4d7d-9917-02396055ecd0">
-----------------------------------------------------------------------------------------------
<img width="1702" alt="image" src="https://github.com/user-attachments/assets/a351543c-cad4-4acb-93c9-d1602be96097">
-----------------------------------------------------------------------------------------------
<img width="1619" alt="image" src="https://github.com/user-attachments/assets/f9a2e49f-f767-49c0-add3-afb46cade70b">
-----------------------------------------------------------------------------------------------
<img width="1660" alt="image" src="https://github.com/user-attachments/assets/db4e8403-ed81-4c74-9de1-d1383041cb4f">


### 2. Textbook page
[The white page of pdf is rendered via pdfViewer/Canvas. It cannot be converted to dark in dark-mode.]
<img width="1702" alt="image" src="https://github.com/user-attachments/assets/7da57204-2bef-49a1-b9cc-3f6d25328fdc">


