### PR TITLE
chore: remove mfe install in github ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,5 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[dev]
-          pip install --upgrade --editable git+https://github.com/overhangio/tutor-mfe.git@main#egg=tutor-mfe
       - name: Test lint, types, and format
         run: make test


### PR DESCRIPTION
Remove tutor-mfe install from main branch. Earlier, tutor-mfe `env.config.js` change wasn't published on pip. So, we included the branch URL to use `env.config.jsx` functionality. After publishing the package with version `v18.1.0`, there is no need to install tutor-mfe via branch URL. 