### PR TITLE
fix: add patches folder to manifest.in to be available on pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include tutorindigo/templates *
+recursive-include tutorindigo/patches *


### PR DESCRIPTION
When installing tutor-indigo via pip install tutor-indigo, the patches folder is not included in the tar.gz package.

#### Effect:
- The Indigo dark theme is not applied.
- The Indigo footer is not applied.

#### Cause:
The `env.config.jsx` file requires imports and the AddDarkTheme component, which are located in the patches folder. Since the patches folder is not being downloaded with the installation, `env.config.jsx` does not produce the expected output.

