### PR TITLE
fix: remove reference to old account toggles

### DIFF
--- a/changelog.d/20250217_135019_ahmed.khalid_remove_old_toggles.md
+++ b/changelog.d/20250217_135019_ahmed.khalid_remove_old_toggles.md
@@ -1,0 +1,1 @@
+- [Bugfix] Remove reference to old account toggles. (by @ahmed-arb)

--- a/tutorindigo/templates/indigo/lms/templates/header/user_dropdown.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/user_dropdown.html
@@ -10,7 +10,6 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
-from openedx.core.djangoapps.user_api.accounts.toggles import should_redirect_to_order_history_microfrontend
 from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name, get_enterprise_learner_portal
 %>
 
@@ -23,7 +22,7 @@ displayname = get_enterprise_learner_generic_name(request) or username
 enterprise_customer_portal = get_enterprise_learner_portal(request)
 ## Enterprises with the learner portal enabled should not show order history, as it does
 ## not apply to the learner's method of purchasing content.
-should_show_order_history = should_redirect_to_order_history_microfrontend() and not enterprise_customer_portal
+should_show_order_history = not enterprise_customer_portal
 %>
 
 <!-- NEW IN INDIGO update user icon -->


### PR DESCRIPTION
Fixes #126 by assuming that the order history should always be displayed if the enterprise doesn't have the learner portal enabled.