### PR TITLE
fix: Fixed dark-theme toggle not working in legacy pages

### DIFF
--- a/changelog.d/20250217_135531_abdul.rehman02_fix_dark_theme_legacy_pages.md
+++ b/changelog.d/20250217_135531_abdul.rehman02_fix_dark_theme_legacy_pages.md
@@ -1,0 +1,1 @@
+- [Bugfix] Fixed breaking dark theme toggle not working in legacy pages. (by @rehmansheikh222) 

--- a/tutorindigo/templates/indigo/lms/static/js/dark-theme.js
+++ b/tutorindigo/templates/indigo/lms/static/js/dark-theme.js
@@ -1,3 +1,11 @@
+(function() {
+  if (window.INDIGO_DARK_THEME_INITIALIZED) {
+    console.log("dark-theme.js: script already initialized, skipping second run.");
+    return;
+  }
+  window.INDIGO_DARK_THEME_INITIALIZED = true;
+  // ========== END GUARD CHECK ===============
+
 $(document).ready(function() {
     'use strict';
 
@@ -36,3 +44,4 @@ $(document).ready(function() {
 
     $('#toggle-switch').on('change', toggleTheme);
 });
+})();


### PR DESCRIPTION
The dark theme toggle button was not working in the legacy pages because of the dark-theme.js file being executed twice as a VM file duplicate of dark-theme.js file is created by the browser so the event for onChange gets triggered twice. This PR puts a guard at the top of the file so that it only executes just once.
![image](https://github.com/user-attachments/assets/fcecc093-0aaa-4adb-b277-af17b6016ecb)
