### PR TITLE
Toggle Theme button accessible using keyboard and Enter press

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/js/dark-theme.js
+++ b/tutorindigo/templates/indigo/lms/static/js/dark-theme.js
@@ -35,4 +35,9 @@ $(document).ready(function() {
     setThemeToggleBtnState(); // check/uncheck toggle btn based on theme
 
     $('#toggle-switch').on('change', toggleTheme);
+    $('#toggle-switch').on('keydown', function (event) {
+      if (event.key === "Enter") {
+          toggleTheme();
+      }
+  });
 });

--- a/tutorindigo/templates/indigo/lms/templates/header/theme-toggle-button.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/theme-toggle-button.html
@@ -1,14 +1,14 @@
 <div class="theme-toggle-button mr-4">
-  <div class="light-theme-icon">
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" role="img" focusable="false" aria-hidden="true"><path d="m6.76 4.84-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 10.5H1v2h3v-2zm9-9.95h-2V3.5h2V.55zm7.45 3.91-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7 1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 10.5v2h3v-2h-3zm-8-5c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm-1 16.95h2V19.5h-2v2.95zm-7.45-3.91 1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z" fill="currentColor"></path></svg>
-  </div>
-  <div id="toggle-switch" tabindex="0">
-    <label class="switch">
-      <input id="toggle-switch-input" type="checkbox" tabindex="-1">
-      <span class="slider round"></span>
-    </label>
-  </div>
-  <div class="dark-theme-icon">
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" role="img" focusable="false" aria-hidden="true"><path d="M14 2c1.82 0 3.53.5 5 1.35-2.99 1.73-5 4.95-5 8.65s2.01 6.92 5 8.65A9.973 9.973 0 0 1 14 22C8.48 22 4 17.52 4 12S8.48 2 14 2z" fill="currentColor"></path></svg>
-  </div> 
+    <div class="light-theme-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" role="img" focusable="false" aria-hidden="true"><path d="m6.76 4.84-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 10.5H1v2h3v-2zm9-9.95h-2V3.5h2V.55zm7.45 3.91-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7 1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 10.5v2h3v-2h-3zm-8-5c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm-1 16.95h2V19.5h-2v2.95zm-7.45-3.91 1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z" fill="currentColor"></path></svg>
+    </div>
+    <div id="toggle-switch" tabindex="0">
+      <label class="switch">
+        <input id="toggle-switch-input" type="checkbox" tabindex="-1">
+        <span class="slider round"></span>
+      </label>
+    </div>
+    <div class="dark-theme-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" role="img" focusable="false" aria-hidden="true"><path d="M14 2c1.82 0 3.53.5 5 1.35-2.99 1.73-5 4.95-5 8.65s2.01 6.92 5 8.65A9.973 9.973 0 0 1 14 22C8.48 22 4 17.52 4 12S8.48 2 14 2z" fill="currentColor"></path></svg>
+    </div> 
 </div>

--- a/tutorindigo/templates/indigo/lms/templates/header/theme-toggle-button.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/theme-toggle-button.html
@@ -1,14 +1,14 @@
 <div class="theme-toggle-button mr-4">
-    <div class="light-theme-icon">
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" role="img" focusable="false" aria-hidden="true"><path d="m6.76 4.84-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 10.5H1v2h3v-2zm9-9.95h-2V3.5h2V.55zm7.45 3.91-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7 1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 10.5v2h3v-2h-3zm-8-5c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm-1 16.95h2V19.5h-2v2.95zm-7.45-3.91 1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z" fill="currentColor"></path></svg>
-    </div>
-    <div id="toggle-switch">
-      <label class="switch">
-        <input id="toggle-switch-input" type="checkbox">
-        <span class="slider round"></span>
-      </label>
-    </div>
-    <div class="dark-theme-icon">
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" role="img" focusable="false" aria-hidden="true"><path d="M14 2c1.82 0 3.53.5 5 1.35-2.99 1.73-5 4.95-5 8.65s2.01 6.92 5 8.65A9.973 9.973 0 0 1 14 22C8.48 22 4 17.52 4 12S8.48 2 14 2z" fill="currentColor"></path></svg>
-    </div> 
+  <div class="light-theme-icon">
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" role="img" focusable="false" aria-hidden="true"><path d="m6.76 4.84-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 10.5H1v2h3v-2zm9-9.95h-2V3.5h2V.55zm7.45 3.91-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7 1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 10.5v2h3v-2h-3zm-8-5c-3.31 0-6 2.69-6 6s2.69 6 6 6 6-2.69 6-6-2.69-6-6-6zm-1 16.95h2V19.5h-2v2.95zm-7.45-3.91 1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z" fill="currentColor"></path></svg>
+  </div>
+  <div id="toggle-switch" tabindex="0">
+    <label class="switch">
+      <input id="toggle-switch-input" type="checkbox" tabindex="-1">
+      <span class="slider round"></span>
+    </label>
+  </div>
+  <div class="dark-theme-icon">
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" role="img" focusable="false" aria-hidden="true"><path d="M14 2c1.82 0 3.53.5 5 1.35-2.99 1.73-5 4.95-5 8.65s2.01 6.92 5 8.65A9.973 9.973 0 0 1 14 22C8.48 22 4 17.52 4 12S8.48 2 14 2z" fill="currentColor"></path></svg>
+  </div> 
 </div>


### PR DESCRIPTION
### Description:
**Steps to Reproduce:**

1. Go to https://sandbox.openedx.edly.io/courses 
2. Navigate the page with the tab button 
3. Go to the theme toggle button

**Actual Result:**
The theme toggle button is not keyboard accessible.

**Expected Result:**
The theme toggle button should be navigated with the keyboard and should therefore be keyboard accessible.

So, I've made Toggle Theme button keyboard accessible in top nav bar.

[Taiga Ticket (If someone have access)](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/110)

Related to https://github.com/overhangio/tutor-indigo/issues/146