### PR TITLE
fix: Added edx-platform patch related to instructor dashboard

### DIFF
--- a/changelog.d/20250407_123240_abdul.rehman02_add_edx_platform_patch.md
+++ b/changelog.d/20250407_123240_abdul.rehman02_add_edx_platform_patch.md
@@ -1,0 +1,1 @@
+[Fix] Fixed dark theme toggle in instructor dashboard by adding edx platform patch (by @rehmansheikh222)

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -188,13 +188,18 @@ for path in glob(
         hooks.Filters.ENV_PATCHES.add_item((os.path.basename(path), patch_file.read()))
 
 # Apply patch from edx platform related to instructor dashboard
-hooks.Filters.ENV_PATCHES.add_items([
-    ("openedx-dockerfile-post-git-checkout", """
+hooks.Filters.ENV_PATCHES.add_items(
+    [
+        (
+            "openedx-dockerfile-post-git-checkout",
+            """
         {%- if not TUTOR_BRANCH_IS_MAIN %}
             RUN curl -fsSL https://github.com/openedx/edx-platform/commit/385ea8382e187ca52e7075f5103e7a9aa1236660.patch | git am
         {%- endif %}
-    """)
-])
+    """,
+        )
+    ]
+)
 
 for mfe in indigo_styled_mfes:
     PLUGIN_SLOTS.add_item(

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -189,7 +189,7 @@ for path in glob(
 
 # Apply patch from edx platform related to instructor dashboard
 hooks.Filters.ENV_PATCHES.add_items([
-    ("openedx-dockerfile-git-patches-default", """
+    ("openedx-dockerfile-post-git-checkout", """
         {%- if not TUTOR_BRANCH_IS_MAIN %}
             RUN curl -fsSL https://github.com/openedx/edx-platform/commit/385ea8382e187ca52e7075f5103e7a9aa1236660.patch | git am
         {%- endif %}

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -187,6 +187,14 @@ for path in glob(
     with open(path, encoding="utf-8") as patch_file:
         hooks.Filters.ENV_PATCHES.add_item((os.path.basename(path), patch_file.read()))
 
+# Apply patch from edx platform related to instructor dashboard
+hooks.Filters.ENV_PATCHES.add_items([
+    ("openedx-dockerfile-git-patches-default", """
+        {%- if not TUTOR_BRANCH_IS_MAIN %}
+            RUN curl -fsSL https://github.com/openedx/edx-platform/commit/385ea8382e187ca52e7075f5103e7a9aa1236660.patch | git am
+        {%- endif %}
+    """)
+])
 
 for mfe in indigo_styled_mfes:
     PLUGIN_SLOTS.add_item(


### PR DESCRIPTION
This PR adds edx-platform patch in the indigo plugin, currently the dark theme toggle does not work in the instructor pages. Although, this issue is related to dual js files imports in the instructor dashboard which was resolved in this [PR](https://github.com/openedx/edx-platform/pull/36289), we still needed to add its patch in our plugin to make our dark theme work properly until the new release is launched.