### PR TITLE
fix: ora grading iframe dark frame issue

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/sass/xblock/_xblock.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/xblock/_xblock.scss
@@ -403,7 +403,7 @@
         }
 
         .tox .tox-edit-area__iframe{
-            background-color: $body-bg-d;
+          background-color: #4e4e4e;
         }
 
         .openassessment .submission__answer__display__title{


### PR DESCRIPTION
Fixed the dark theme issue within ora grading. The only solution I could come up with was to change the background color instead of the text color. The issue was that an iframe within an iframe didn't allow us to target styles.

Fixes https://github.com/overhangio/tutor-indigo/issues/120