### PR TITLE
fix: correct language switch URL in header.html

### DIFF
--- a/tutorindigo/templates/indigo/lms/templates/header/header.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/header.html
@@ -92,7 +92,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
             % if user.is_authenticated:
                 <input title="preference api" type="hidden" class="url-endpoint" value="${reverse('preferences_api', kwargs={'username': user.username})}" data-user-is-authenticated="true">
             % else:
-                <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('session_language')}" data-user-is-authenticated="false">
+                <input title="session update url" type="hidden" class="url-endpoint" value="${reverse('update_language')}" data-user-is-authenticated="false">
             % endif
             <label><span class="sr">${_("Choose Language")}</span>
             <select class="input select language-selector" id="settings-language-value" name="language">


### PR DESCRIPTION
### Problem
The language switch dropdown in the Tutor Indigo theme was generating incorrect URLs due to the use of 'session_language' in `header.html`.

### Solution
Replaced 'session_language' with 'update_language' in the `header.html` file to ensure correct URL generation for language switching.

### Testing
- Enabled multiple languages in Open edX.
- Verified that the language switch dropdown now generates the correct URLs and functions as expected.

### Screenshots
![Screenshot from 2025-04-09 13-11-02](https://github.com/user-attachments/assets/583775b0-18f8-4f70-b6dc-7c077124fba8)
