### PR TITLE
fix: bump indigo header and footer versions

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -119,8 +119,8 @@ hooks.Filters.ENV_PATCHES.add_items(
             f"mfe-dockerfile-post-npm-install-{mfe}",
             """
            
-RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
-RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.2.2'
+RUN npm install @edly-io/indigo-frontend-component-footer@^3.0.0
+RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^4.0.0'
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.2.2'
 
 """,


### PR DESCRIPTION
Bump Indigo header and footer versions to fix the Issue https://github.com/overhangio/tutor-indigo/issues/142.

Steps to verify the fix:
- checkout the indigo `fix/bump-indigo-packages-versions` branch.
- mount `master` branch of any MFE and build {mfe}-dev image.

The image should build without any issues while installing indigo-footer V3 and indigo-header V4. 