### PR TITLE
Fix Accessibility Issues Reported During Accessibility Review

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/js/dark-theme.js
+++ b/tutorindigo/templates/indigo/lms/static/js/dark-theme.js
@@ -35,4 +35,9 @@ $(document).ready(function() {
     setThemeToggleBtnState(); // check/uncheck toggle btn based on theme
 
     $('#toggle-switch').on('change', toggleTheme);
+    $('#toggle-switch-input').on('keydown', function (event) {
+      if (event.key === "Enter") {
+          toggleTheme();
+      }
+    });
 });

--- a/tutorindigo/templates/indigo/lms/static/sass/courseware/_about.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/courseware/_about.scss
@@ -94,25 +94,34 @@
         @include media-breakpoint-up(md) {
             margin: -50px 0 0;
         }
+        span {
+          &.register {
+            &.disabled {
+              display: inline-block;
+              vertical-align: top;
+              padding: 7px 14px;
+              color: #374151;
+              border-radius: 6px;
+              background: #fff;
+              font-size: 16px;
+              line-height: 24px;
+              font-weight: 500;
+              text-decoration: none !important;
+              border: 1px solid #D1D5DB;
+              margin-right: 20px;
+              @include media-breakpoint-up(md) {
+                  padding: 12px 24px;
+              }
+
+              &:hover {
+                opacity: 1;
+              }
+            }
+          }
+        }
+
         a {
             text-decoration: none !important;
-            span {
-                display: inline-block;
-                vertical-align: top;
-                padding: 7px 14px;
-                color: #374151;
-                border-radius: 6px;
-                background: #fff;
-                font-size: 16px;
-                line-height: 24px;
-                font-weight: 500;
-                text-decoration: none !important;
-                border: 1px solid #D1D5DB;
-                margin-right: 20px;
-                @include media-breakpoint-up(md) {
-                    padding: 12px 24px;
-                }
-            }
         }
         a.register, a strong, >span.register, a.add-to-cart {
             display: inline-block;

--- a/tutorindigo/templates/indigo/lms/static/sass/courseware/_about.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/courseware/_about.scss
@@ -121,6 +121,7 @@
         }
 
         a {
+            display: inline-block;
             text-decoration: none !important;
         }
         a.register, a strong, >span.register, a.add-to-cart {

--- a/tutorindigo/templates/indigo/lms/static/sass/courseware/_discover.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/courseware/_discover.scss
@@ -164,6 +164,7 @@
 }
 .saerch-bar-discover {
     margin:  0 0 25px;
+    display: flex;
     @include media-breakpoint-up(md) {
         margin:  0 0 30px;
     }
@@ -196,12 +197,11 @@
         }
     }
     .discover-search {
-        overflow: hidden;
+        width: 100%;
         .wrapper-search-context {
-            overflow: hidden;
             .wrapper-search-input {
                 float: none;
-                display: block;
+                display: flex;
                 margin: 0;
                 width: auto;
                 &:after {
@@ -237,7 +237,7 @@
                     }
                 }
                 .input-holder {
-                    overflow: hidden;
+                    flex-grow: 1;
                     border-radius: 6px;
                     background: $primary-light;
                     padding: 0 0 0 33px;
@@ -275,9 +275,12 @@
     }
 }
 .filter-block {
-    float: left;
+    flex: 0 0 80px;
     position: relative;
     z-index: 9;
+    @include media-breakpoint-up(sm) {
+      flex: 0 0 130px;
+    }
     &.show {
         .dropdown-menu {
             display: block;
@@ -430,7 +433,7 @@ body.indigo-dark-theme {
                         svg {
                            path {
                                 color: $text-color-d;
-                           } 
+                           }
                         }
                         input {
                             color: $text-color-d;
@@ -443,7 +446,7 @@ body.indigo-dark-theme {
             }
         }
         .filter-block {
-           
+
             >a {
                 background-color: $primary-light-d;
                 color: $text-color-d;

--- a/tutorindigo/templates/indigo/lms/static/sass/extra/_header.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/extra/_header.scss
@@ -119,10 +119,15 @@ header.global-header {
         }
     }
     .hamburger-menu {
-        height: 12px;
+        height: 17px;
         width: 20px;
         left: 15px;
         top: 18px;
+        background: none;
+        border: 0;
+        padding: 0;
+        box-shadow: none;
+
         .line {
             height: 2px;
             &:nth-child(2), &:nth-child(3) {

--- a/tutorindigo/templates/indigo/lms/static/sass/extra/_header.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/extra/_header.scss
@@ -215,6 +215,13 @@ header.global-header {
                 opacity: 0;
                 width: 0;
                 height: 0;
+
+              &:focus {
+                ~ .slider {
+                  outline: 2px solid $primary;
+                  outline-offset: 1px;
+                }
+              }
             }
 
             /* The slider */
@@ -331,6 +338,13 @@ body.indigo-dark-theme {
         }
         #toggle-switch {
             .switch {
+                input {
+                  &:focus {
+                    ~ .slider {
+                      outline-color: $primary-d;
+                    }
+                  }
+                }
                 /* The slider */
                 .slider {
                     background-color: #ccc;

--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
@@ -448,6 +448,9 @@ body.view-instructordash {
           &:hover {
             color: $dark;
           }
+          &:focus {
+            box-shadow: inset 0 0 0 2px $primary !important;
+          }
         }
       }
     }
@@ -892,6 +895,9 @@ body.indigo-dark-theme {
             }
             &:hover {
               color: $text-color-d;
+            }
+            &:focus {
+              box-shadow: inset 0 0 0 2px #E5E7EB !important;
             }
           }
         }

--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_variables.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_variables.scss
@@ -30,7 +30,7 @@ $light-overlay-d: #36383B;
 $danger-d: #FFA07A;
 $success-d: #54CF5E;
 $btn-color-d: #112F6B;
-$body-bg-d:#0D0D0E;
+$body-bg-d: #0D0D0E;
 
 $warning-400: #ffe340;
 $page-color-transition: transparent .2s ease, color .2s ease;

--- a/tutorindigo/templates/indigo/lms/templates/courseware/course_about.html
+++ b/tutorindigo/templates/indigo/lms/templates/courseware/course_about.html
@@ -89,7 +89,6 @@ from openedx.core.lib.courses import course_image_url
           %if show_courseware_link:
             <a href="${course_target}">
           %endif
-          <span class="register disabled">${_("Already Enrolled")}</span>
           %if show_courseware_link:
             <strong>${_("View Course")}</strong>
             </a>

--- a/tutorindigo/templates/indigo/lms/templates/courseware/course_about.html
+++ b/tutorindigo/templates/indigo/lms/templates/courseware/course_about.html
@@ -85,12 +85,11 @@ from openedx.core.lib.courses import course_image_url
       </div>
       <div class="main-cta">
         %if user.is_authenticated and registered:
+        <span class="register disabled">${_("Already Enrolled")}</span>
           %if show_courseware_link:
             <a href="${course_target}">
           %endif
-
           <span class="register disabled">${_("Already Enrolled")}</span>
-
           %if show_courseware_link:
             <strong>${_("View Course")}</strong>
             </a>

--- a/tutorindigo/templates/indigo/lms/templates/courseware/courses.html
+++ b/tutorindigo/templates/indigo/lms/templates/courseware/courses.html
@@ -67,16 +67,16 @@
             <div id="discovery-form" role="search" aria-label="course" class="wrapper-search-context">
               <form class="wrapper-search-input">
                 <label for="discovery-input" class="sr">${_('Search for a course')}</label>
-                <div class="button-holder">
-                  <button type="submit" class="button postfix discovery-submit" title="${_('Search')}">
-                    Search
-                  </button>
-                </div>
                 <div class="input-holder">
                   <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M8 4C5.79086 4 4 5.79086 4 8C4 10.2091 5.79086 12 8 12C10.2091 12 12 10.2091 12 8C12 5.79086 10.2091 4 8 4ZM2 8C2 4.68629 4.68629 2 8 2C11.3137 2 14 4.68629 14 8C14 9.29583 13.5892 10.4957 12.8907 11.4765L17.7071 16.2929C18.0976 16.6834 18.0976 17.3166 17.7071 17.7071C17.3166 18.0976 16.6834 18.0976 16.2929 17.7071L11.4765 12.8907C10.4957 13.5892 9.29583 14 8 14C4.68629 14 2 11.3137 2 8Z" fill="#9CA3AF"/>
                     </svg>
                   <input id="discovery-input" class="discovery-input" placeholder="${_('Explore course')}" type="text"/>
+                </div>
+                <div class="button-holder">
+                  <button type="submit" class="button postfix discovery-submit" title="${_('Search')}">
+                    Search
+                  </button>
                 </div>
               </form>
               <div id="discovery-message" class="search-status-label"></div>

--- a/tutorindigo/templates/indigo/lms/templates/header/header.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/header.html
@@ -52,13 +52,13 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
         )}
     % endif
     <div class="main-header">
-        <%include file="navbar-logo-header.html" args="online_help_token=online_help_token"/>
-        <div class="hamburger-menu" role="button" aria-label=${_("Options Menu")} aria-expanded="false" aria-controls="mobile-menu" tabindex="0">
-            <span class="line"></span>
-            <span class="line"></span>
-            <span class="line"></span>
-            <span class="line"></span>
-        </div>
+      <button class="hamburger-menu" role="button" aria-label=${_("Options Menu")} aria-expanded="false" aria-controls="mobile-menu" tabindex="0">
+        <span class="line"></span>
+        <span class="line"></span>
+        <span class="line"></span>
+        <span class="line"></span>
+      </button>
+      <%include file="navbar-logo-header.html" args="online_help_token=online_help_token"/>
         % if user.is_authenticated:
             <%include file="navbar-authenticated.html" args="online_help_token=online_help_token"/>
         % else:


### PR DESCRIPTION
### Description

This pull request resolves several accessibility issues in the Tutor Indigo theme that were identified during a recent accessibility review. These updates aim to improve usability for all users, especially those relying on assistive technologies. The changes also help ensure compliance with recognized accessibility standards, such as the Web Content Accessibility Guidelines (WCAG) 2.1.

For further details, please refer to the related issue: [overhangio/tutor-indigo#146](https://github.com/overhangio/tutor-indigo/issues/146).

---

### Accessibility Fixes Implemented

#### Search Bar Focus Correct Order

The search bar on the progress page was receiving keyboard focus after the search button, which disrupted the expected tab order. This has been corrected so that the search bar receives focus before the button.

- **Code Commit:** [TIA-111 Search bar focus correct order](https://github.com/overhangio/tutor-indigo/commit/a1c9bd7c8f07ece98c13a996adc73e390ea497ac)
- **Issue:** [Taiga - US/111](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/111)
- **Live Example:** [Progress Page](https://apps.sandbox.openedx.edly.io/learning/course/course-v1:OpenedX+DemoX+DemoCourse/progress)

---

#### Makes the Focus Visible on the Navigation Bar

On the instructor dashboard, the focus state for navigation items like "Course Info" was not visible. This has been fixed by adding clear outlines to indicate keyboard focus.

- **Code Commit:** [TIA-98 Instructor Dashboard - Makes focus visible and outlined on navigation bar](https://github.com/overhangio/tutor-indigo/commit/c669e05ca5d3e3fc1990eed8faa90671b55b6d70)
- **Issue:** [Taiga - US/98](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/98)
- **Live Example:** [Instructor Dashboard](https://sandbox.openedx.edly.io/courses/course-v1:OpenedX+DemoX+DemoCourse/instructor#view-course_info)

---

#### Focus on the Theme Toggle Button

The theme toggle button lacked a visible focus indicator for keyboard users. This has been addressed by ensuring a clear focus style is applied.

- **Code Commit:** [Appears the focus on the theme toggle button](https://github.com/overhangio/tutor-indigo/commit/5ae5b1d15d8dcb684424751fc1d70a17baf80275)  
- **Issue:** [Taiga - US/139](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/139)
- **Live Example:** [Home Page](https://sandbox.openedx.edly.io/)
- **Linked Pull Requests:** [MFE Header](https://github.com/edly-io/frontend-component-header/pull/27 ) - [Brand Openedx](https://github.com/edly-io/brand-openedx/pull/35)

---

#### Remove Focus from the "Already Enrolled" Button

Previously, the "Already Enrolled" and "View Course" buttons were highlighted simultaneously, creating confusion. This issue has been fixed so that focus is only applied to the appropriate interactive element.

- **Code Commit:** [Remove focus from the Already Enrolled Button](https://github.com/overhangio/tutor-indigo/commit/25cb1145cfff99f79b18c24cd7a38f848b466df5)  
- **Issue:** [Taiga - US/64](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/64)
- **Live Example:** [Course About Page](https://sandbox.openedx.edly.io/courses/course-v1:OpenedX+DemoX+DemoCourse/about)

---

### Accessibility Audit Report

For the full audit and issue breakdown, please refer to the following report:  
[Accessibility Audit - Taiga US/111](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/111)

