### PR TITLE
fix: import footer only in supported MFEs

### DIFF
--- a/changelog.d/20250505_200616_ahmed.khalid_fix_mfe_footer_import.md
+++ b/changelog.d/20250505_200616_ahmed.khalid_fix_mfe_footer_import.md
@@ -1,0 +1,1 @@
+- [BugFix] Only import footer in the MFEs that have it installed. (by @ahmed-arb)

--- a/changelog.d/20250505_200616_ahmed.khalid_fix_mfe_footer_import.md
+++ b/changelog.d/20250505_200616_ahmed.khalid_fix_mfe_footer_import.md
@@ -1,1 +1,1 @@
-- [BugFix] Only import footer in the MFEs that have it installed. (by @ahmed-arb)
+- [BugFix] Fix runtime footer import error in env.config.jsx for unsupported MFEs. (by @ahmed-arb)

--- a/tutorindigo/patches/mfe-env-config-runtime-definitions
+++ b/tutorindigo/patches/mfe-env-config-runtime-definitions
@@ -1,2 +1,0 @@
-
-const { default: IndigoFooter } = await import('@edly-io/indigo-frontend-component-footer');

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -120,8 +120,8 @@ for mfe in indigo_styled_mfes:
             (
                 f"mfe-dockerfile-post-npm-install-{mfe}",
                 """
-RUN npm install @edly-io/indigo-frontend-component-footer@^3.0.0
-RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^4.0.0'
+RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
+RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.2.2'
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.2.2'
 
 """,

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -114,9 +114,8 @@ indigo_styled_mfes = [
 ]
 
 
-mfe_patch_items = []
 for mfe in indigo_styled_mfes:
-    mfe_patch_items.append(
+    hooks.Filters.ENV_PATCHES.add_items([(
         (
             f"mfe-dockerfile-post-npm-install-{mfe}",
             """
@@ -126,17 +125,14 @@ RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.2.2'
 
 """,
         )
-    )
-    mfe_patch_items.append(
+    ),(
         (
             f"mfe-env-config-runtime-definitions-{mfe}",
             """
 const { default: IndigoFooter } = await import('@edly-io/indigo-frontend-component-footer');
 """,
         )
-    )
-
-hooks.Filters.ENV_PATCHES.add_items(mfe_patch_items)
+    )])
 
 
 hooks.Filters.ENV_PATCHES.add_item(

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -113,21 +113,30 @@ indigo_styled_mfes = [
     "discussions",
 ]
 
-hooks.Filters.ENV_PATCHES.add_items(
-    [
+
+mfe_patch_items = []
+for mfe in indigo_styled_mfes:
+    mfe_patch_items.append(
         (
             f"mfe-dockerfile-post-npm-install-{mfe}",
             """
-           
-RUN npm install @edly-io/indigo-frontend-component-footer@^2.0.0
-RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^3.2.2'
+RUN npm install @edly-io/indigo-frontend-component-footer@^3.0.0
+RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^4.0.0'
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.2.2'
 
 """,
         )
-        for mfe in indigo_styled_mfes
-    ]
-)
+    )
+    mfe_patch_items.append(
+        (
+            f"mfe-env-config-runtime-definitions-{mfe}",
+            """
+const { default: IndigoFooter } = await import('@edly-io/indigo-frontend-component-footer');
+""",
+        )
+    )
+
+hooks.Filters.ENV_PATCHES.add_items(mfe_patch_items)
 
 
 hooks.Filters.ENV_PATCHES.add_item(

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -115,24 +115,25 @@ indigo_styled_mfes = [
 
 
 for mfe in indigo_styled_mfes:
-    hooks.Filters.ENV_PATCHES.add_items([(
-        (
-            f"mfe-dockerfile-post-npm-install-{mfe}",
-            """
+    hooks.Filters.ENV_PATCHES.add_items(
+        [
+            (
+                f"mfe-dockerfile-post-npm-install-{mfe}",
+                """
 RUN npm install @edly-io/indigo-frontend-component-footer@^3.0.0
 RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^4.0.0'
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.2.2'
 
 """,
-        )
-    ),(
-        (
-            f"mfe-env-config-runtime-definitions-{mfe}",
-            """
+            ),
+            (
+                f"mfe-env-config-runtime-definitions-{mfe}",
+                """
 const { default: IndigoFooter } = await import('@edly-io/indigo-frontend-component-footer');
 """,
-        )
-    )])
+            ),
+        ]
+    )
 
 
 hooks.Filters.ENV_PATCHES.add_item(


### PR DESCRIPTION
## 📄 Description
This PR ensures that the Indigo footer component is only imported in MFEs that have the package installed. This avoids potential runtime errors in MFEs that do not include the `@edly-io/indigo-frontend-component-footer` dependency.

## 💡 Motivation
Unconditional installation of dependencies was breaking the plugin slots mechanism in tutor-mfe.