### PR TITLE
fix: footer import issue in unsupported MFEs

### DIFF
--- a/changelog.d/20250505_200616_ahmed.khalid_fix_mfe_footer_import.md
+++ b/changelog.d/20250505_200616_ahmed.khalid_fix_mfe_footer_import.md
@@ -1,0 +1,1 @@
+- [BugFix] Fix runtime footer import error in env.config.jsx for unsupported MFEs. (by @ahmed-arb)

--- a/tutorindigo/patches/mfe-env-config-runtime-definitions
+++ b/tutorindigo/patches/mfe-env-config-runtime-definitions
@@ -1,2 +1,0 @@
-
-const { default: IndigoFooter } = await import('@edly-io/indigo-frontend-component-footer');

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -113,21 +113,27 @@ indigo_styled_mfes = [
     "discussions",
 ]
 
-hooks.Filters.ENV_PATCHES.add_items(
-    [
-        (
-            f"mfe-dockerfile-post-npm-install-{mfe}",
-            """
-           
+
+for mfe in indigo_styled_mfes:
+    hooks.Filters.ENV_PATCHES.add_items(
+        [
+            (
+                f"mfe-dockerfile-post-npm-install-{mfe}",
+                """
 RUN npm install @edly-io/indigo-frontend-component-footer@^3.0.0
 RUN npm install '@edx/frontend-component-header@npm:@edly-io/indigo-frontend-component-header@^4.0.0'
 RUN npm install '@edx/brand@npm:@edly-io/indigo-brand-openedx@^2.2.2'
 
 """,
-        )
-        for mfe in indigo_styled_mfes
-    ]
-)
+            ),
+            (
+                f"mfe-env-config-runtime-definitions-{mfe}",
+                """
+const { default: IndigoFooter } = await import('@edly-io/indigo-frontend-component-footer');
+""",
+            ),
+        ]
+    )
 
 
 hooks.Filters.ENV_PATCHES.add_item(


### PR DESCRIPTION
This PR brings changes from the release with conflict resolution.
Ref: https://github.com/overhangio/tutor-indigo/pull/148