### PR TITLE
fix: Ensure decorative images do not interfere with screen readers

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -78,7 +78,7 @@ with open(
 # Override openedx & mfe docker image names
 @hooks.Filters.CONFIG_DEFAULTS.add(priority=hooks.priorities.LOW)
 def _override_openedx_docker_image(
-    items: list[tuple[str, t.Any]]
+    items: list[tuple[str, t.Any]],
 ) -> list[tuple[str, t.Any]]:
     openedx_image = ""
     mfe_image = ""

--- a/tutorindigo/templates/indigo/lms/templates/courseware/course_about.html
+++ b/tutorindigo/templates/indigo/lms/templates/courseware/course_about.html
@@ -64,7 +64,7 @@ from openedx.core.lib.courses import course_image_url
         % if get_course_about_section(request, course, "video"):
         <a href="#video-modal" class="media" rel="leanModal">
           <div class="hero">
-            <img src="${course_image_urls['large']}" alt="" />
+            <img src="${course_image_urls['large']}" alt="" aria-hidden="true" />
             <div class="play-intro"></div>
           </div>
         </a>
@@ -72,7 +72,7 @@ from openedx.core.lib.courses import course_image_url
         <div class="media">
           <div class="hero">
             <!-- NEW IN INDIGO: Add fallback image in case of no course-image using onerror -->
-            <img src="${course_image_urls['large']}" onerror="this.src='/theming/asset/images/no_course_image.png';" alt="" />
+            <img src="${course_image_urls['large']}" onerror="this.src='/theming/asset/images/no_course_image.png';" alt="" aria-hidden="true" />
           </div>
         </div>
         % endif
@@ -158,7 +158,7 @@ from openedx.core.lib.courses import course_image_url
         <%block name="course_about_important_dates">
         <ol class="important-dates">
           <li class="important-dates-item">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
               <path fill-rule="evenodd" clip-rule="evenodd" d="M12 3L1 9L5 11.18V17.18L12 21L19 17.18V11.18L21 10.09V17H23V9L12 3ZM18.8201 8.99997L12.0001 12.72L5.18007 8.99997L12.0001 5.27997L18.8201 8.99997ZM12 18.72L17 15.99V12.27L12 15L7 12.27V15.99L12 18.72Z" fill="#9CA3AF"/>
               </svg>
             <p class="important-dates-item-title">${_("Course Number")}</p><span class="important-dates-item-text course-number">${course.display_number_with_default}</span></li>
@@ -167,7 +167,7 @@ from openedx.core.lib.courses import course_image_url
                   course_start_date = course.advertised_start or course.start
               %>
             <li class="important-dates-item">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M18 4H19C20.1 4 21 4.9 21 6V20C21 21.1 20.1 22 19 22H5C3.89 22 3 21.1 3 20L3.01 6C3.01 4.9 3.89 4 5 4H6V2H8V4H16V2H18V4ZM5 10V20H19V10H5ZM19 8H5V6H19V8ZM17 13H12V18H17V13Z" fill="#9CA3AF"/>
                 </svg>
               <p class="important-dates-item-title">${_("Classes Start")}</p>
@@ -189,7 +189,7 @@ from openedx.core.lib.courses import course_image_url
                 %>
 
             <li class="important-dates-item">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M18 4H19C20.1 4 21 4.9 21 6V20C21 21.1 20.1 22 19 22H5C3.89 22 3 21.1 3 20L3.01 6C3.01 4.9 3.89 4 5 4H6V2H8V4H16V2H18V4ZM5 10V20H19V10H5ZM19 8H5V6H19V8ZM17 13H12V18H17V13Z" fill="#9CA3AF"/>
                 </svg>
                 <p class="important-dates-item-title">${_("Classes End")}</p>

--- a/tutorindigo/templates/indigo/lms/templates/courseware/course_about_sidebar_header.html
+++ b/tutorindigo/templates/indigo/lms/templates/courseware/course_about_sidebar_header.html
@@ -50,17 +50,17 @@ from django.conf import settings
       %>
       <!-- NEW IN INDIGO socialnetworks is improved with better SVGs icons -->
       <a href="${tweet_action}" class="share">
-        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
           <path d="M13.682 1.6875H16.1641L10.743 7.88203L17.1203 16.3125H12.1281L8.21523 11.2008L3.74336 16.3125H1.25781L7.05508 9.68555L0.941406 1.6875H6.06016L9.59336 6.35977L13.682 1.6875ZM12.8102 14.8289H14.1848L5.31133 3.09375H3.83477L12.8102 14.8289Z" fill="#9CA3AF"/>
           </svg><span class="sr">${_("Tweet that you've enrolled in this course")}</span>
       </a>
       <a href="${facebook_link}" class="share">
-        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M18 9.05524C18 4.05403 13.9707 6.29184e-07 9 4.05324e-07C4.0293 1.81463e-07 2.31733e-07 4.05403 5.17607e-07 9.05524C7.75944e-07 13.5747 3.2913 17.3209 7.5942 18L7.5942 11.6731L5.3082 11.6731L5.3082 9.05524L7.5942 9.05524L7.5942 7.06037C7.5942 4.79113 8.937 3.53788 10.9935 3.53788C11.9781 3.53788 13.0077 3.71446 13.0077 3.71446L13.0077 5.94205L11.8737 5.94205C10.755 5.94205 10.4067 6.6402 10.4067 7.35647L10.4067 9.05524L12.9024 9.05524L12.5037 11.6722L10.4067 11.6722L10.4067 18C14.7087 17.3209 18 13.5747 18 9.05524Z" fill="#9CA3AF"/>
           </svg><span class="sr">${_("Post a Facebook message to say you've enrolled in this course")}</span>
       </a>
       <a href="${email_link}" class="share">
-        <svg xmlns="http://www.w3.org/2000/svg" width="22" height="17" viewBox="0 0 22 17" fill="none">
+        <svg xmlns="http://www.w3.org/2000/svg" width="22" height="17" viewBox="0 0 22 17" fill="none" aria-hidden="true">
           <path d="M21 2.85763C21 1.83593 20.1 1 19 1H3C1.9 1 1 1.83593 1 2.85763M21 2.85763V14.0034C21 15.0251 20.1 15.861 19 15.861H3C1.9 15.861 1 15.0251 1 14.0034V2.85763M21 2.85763L11 9.35932L1 2.85763" stroke="#9CA3AF" stroke-linecap="round" stroke-linejoin="round"/>
           </svg><span class="sr">${_("Email someone to say you've enrolled in this course")}</span>
       </a>

--- a/tutorindigo/templates/indigo/lms/templates/discovery/course_card.underscore
+++ b/tutorindigo/templates/indigo/lms/templates/discovery/course_card.underscore
@@ -2,7 +2,7 @@
         <header class="course-image">
             <div class="cover-image">
                 <!-- NEW IN INDIGO: Add fallback image in case of no course-image using onerror -->
-                <img src="<%- image_url %>" onerror="this.src='/theming/asset/images/no_course_image.png';" alt="<%- content.display_name %> <%- content.number %>" />
+                <img src="<%- image_url %>" onerror="this.src='/theming/asset/images/no_course_image.png';" alt="" />
             </div>
         </header>
         <section class="course-info" aria-hidden="true">

--- a/tutorindigo/templates/indigo/lms/templates/discovery/course_card.underscore
+++ b/tutorindigo/templates/indigo/lms/templates/discovery/course_card.underscore
@@ -13,7 +13,7 @@
             </h2>
             <a href="/courses/<%- course %>/about" class="learn-more"><%- gettext("Learn More") %></a>
             <div class="course-date" aria-hidden="true">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="21" viewBox="0 0 20 21" fill="none">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="21" viewBox="0 0 20 21" fill="none" aria-hidden="true">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M15 3.83332H15.8333C16.75 3.83332 17.5 4.58332 17.5 5.49999V17.1667C17.5 18.0833 16.75 18.8333 15.8333 18.8333H4.16667C3.24167 18.8333 2.5 18.0833 2.5 17.1667L2.50833 5.49999C2.50833 4.58332 3.24167 3.83332 4.16667 3.83332H5V2.16666H6.66667V3.83332H13.3333V2.16666H15V3.83332ZM4.16667 8.83332V17.1667H15.8333V8.83332H4.16667ZM15.8333 7.16666H4.16667V5.49999H15.8333V7.16666ZM14.1667 11.3333H10V15.5H14.1667V11.3333Z" fill="#9CA3AF"/>
           </svg>
                 <%- interpolate(


### PR DESCRIPTION
## 📄 Description

This PR resolves an accessibility issue found on the **About Page** of the Tutor Indigo Theme, where the **Twitter**, **Facebook**, and **Email** icons did not have accessible names. This was flagged under **WCAG Success Criterion 1.1.1 – Non-text Content**, which requires that meaningful icons must provide a text alternative for assistive technologies.

For further details, please refer to the related issue: https://github.com/overhangio/tutor-indigo/issues/146.

---

## 🎯 Issue

* **Actual Result:**
  The Twitter, Facebook, Email, and Calendar icons did not have accessible names, making them unreadable by screen readers.
  The course images are decorative and have an alt text.
  
* **Expected Behaviour:**
  These icons should have accessible names to clearly convey their purpose to screen reader users.
  The course images are decorative and should not be given an alt text.
  
Taiga Tickets:
1- https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/68
2- https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/69
3- https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/142
4- https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/119



---

## ✅ Fix

To address this issue without causing duplicate announcements by screen readers, the following changes were made:

* Applied `aria-hidden="true"` to the SVG elements representing the social media icons.
* Ensured that accessible names are provided via surrounding or adjacent text elements (e.g., screen reader-only text or linked context), allowing screen readers to interpret the function of each icon correctly without redundancy.
* An alt text is removed from the course decorative image.

This approach maintains **semantic clarity** and **accessibility compliance** while avoiding content duplication.

---

## 📸 Before & After

### Before 
![image](https://github.com/user-attachments/assets/c42495de-5f0d-4d69-811d-4b3c9ffebc7d)


### After 
![image](https://github.com/user-attachments/assets/9b427c45-65f0-4f78-a463-d2b8d78542a8)

