### PR TITLE
feat: enhance accessibility by adding descriptive label to theme toggle

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -78,7 +78,7 @@ with open(
 # Override openedx & mfe docker image names
 @hooks.Filters.CONFIG_DEFAULTS.add(priority=hooks.priorities.LOW)
 def _override_openedx_docker_image(
-    items: list[tuple[str, t.Any]]
+    items: list[tuple[str, t.Any]],
 ) -> list[tuple[str, t.Any]]:
     openedx_image = ""
     mfe_image = ""

--- a/tutorindigo/templates/indigo/lms/static/js/dark-theme.js
+++ b/tutorindigo/templates/indigo/lms/static/js/dark-theme.js
@@ -10,11 +10,25 @@ $(document).ready(function() {
       // update expiry
       $.cookie(themeCookie, theme, { domain: window.location.hostname, expires: 90, path: '/' });
       {% endif %}
+      updateAccessibility();
     }
 
     function setThemeToggleBtnState(){
       const theme = $.cookie(themeCookie);
       $("#toggle-switch-input").prop("checked", theme === 'dark');
+      updateAccessibility();
+    }
+
+    function updateAccessibility() {
+      const theme = $.cookie(themeCookie);
+      const textWrapper = $('#theme-label');
+      if (theme === 'dark') {
+        textWrapper.text('Switch to Light Mode');
+        textWrapper.attr('aria-checked', 'true');
+      } else {
+        textWrapper.text('Switch to Dark Mode');
+        textWrapper.attr('aria-checked', 'false');
+      }
     }
     
     function toggleTheme(){

--- a/tutorindigo/templates/indigo/lms/templates/header/theme-toggle-button.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/theme-toggle-button.html
@@ -6,6 +6,7 @@
       <label class="switch">
         <input id="toggle-switch-input" type="checkbox">
         <span class="slider round"></span>
+        <span id="theme-label" class="sr-only">Switch to Dark Mode</span>
       </label>
     </div>
     <div class="dark-theme-icon">


### PR DESCRIPTION
## 📄 Description

This PR enhances the **accessibility** of the **theme toggle switch** in the shared header component by improving how it is announced to screen readers. This update ensures users who rely on assistive technologies can understand the purpose of the toggle and interact with it effectively.

The change aligns with **WCAG Success Criterion 4.1.2 – Name, Role, Value**, which requires that user interface elements expose meaningful names and roles programmatically.

---

## 🎯 Issue

* **Actual Result:**
  The theme toggle (used to switch between light and dark modes) did not have an accessible name. As a result, screen readers could not interpret or announce its function, making it difficult for visually impaired users to understand its purpose.

* **Expected Behaviour:**
  The toggle should expose a descriptive label to screen readers that clearly communicates its action — for example, “Switch to dark theme.”

---

## ✅ Fix

* Improved screen reader accessibility by programmatically exposing a meaningful name for the theme toggle control.

---

## 🔗 Related

* **Live Preview:** [[Learner Dashboard – Home](https://apps.sandbox.openedx.edly.io/learner-dashboard/)](https://apps.sandbox.openedx.edly.io/learner-dashboard/)
* **Taiga Ticket (if you have access):** [[US 80 – Add accessible name to theme toggle](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/80)](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/80)
* **Related GitHub Issue:** [[tutor-indigo/#146](https://github.com/overhangio/tutor-indigo/issues/146)](https://github.com/overhangio/tutor-indigo/issues/146)


