### PR TITLE
feat: increase focus visible thickness

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_extras.scss
@@ -33,6 +33,11 @@ input:-webkit-autofill:active{
   border: none;
 }
 
+:focus,
+:focus-visible {
+    outline-width: 2px;
+}
+
 %btn-pl-default-base {
   border-radius: 0;
 }


### PR DESCRIPTION
### 📝 Description

This PR improves keyboard accessibility by updating the global focus styles to comply with **WCAG 2.4.11 – Focus Appearance (Minimum)**.

Previously, the focus indicators on interactive elements were only **1px thick**, which falls short of the minimum visibility requirements. The update ensures that:

- All focusable elements now have a clearly visible **2px focus outline**.
- Keyboard users can more easily identify which element is currently focused.

**Related issue:** [tutor-indigo/#146](https://github.com/overhangio/tutor-indigo/issues/146)  
**Taiga Task (if accessible):** [US 70 – Focus indicator thickness compliance](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/70)

---

### 🧪 How Has This Been Tested?

- Manually tested using keyboard navigation (Tab/Shift+Tab) to confirm that the updated 2px outline is applied consistently.
- Verified that the visual focus remains unobtrusive but clearly visible across various UI components.

---

### 🖼️ Screenshots/Sandbox (optional):

**Live Preview:** [View Sandbox](https://apps.sandbox.openedx.edly.io/)

| Before | After |
|--------|-------|
| 1px thin focus outline | 2px thick focus outline |

**Before**
<img width="552" alt="image" src="https://github.com/user-attachments/assets/7102cf1c-7a26-447f-9270-0a30123f5307" />

**After**
<img width="552" alt="image" src="https://github.com/user-attachments/assets/de50b6ac-86d9-4b17-a5e3-8c2ba2335269" />


---

### 📄 Accessibility Audit Report

For the full audit and issue breakdown, please refer to the following report: [Accessibility Audit](https://github.com/overhangio/tutor-indigo/issues/146)
