### PR TITLE
fix: maintain selected emoji color in survey xblock

### DIFF
--- a/changelog.d/20250516_193402_muhammad.labeeb_fix_emoji_survey.md
+++ b/changelog.d/20250516_193402_muhammad.labeeb_fix_emoji_survey.md
@@ -1,0 +1,1 @@
+ - [BugFix] Maintain selected emoji color in survey xblock. (by @mlabeeb03)

--- a/tutorindigo/templates/indigo/lms/static/sass/xblock/_xblock.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/xblock/_xblock.scss
@@ -474,6 +474,21 @@
 
     .emoji-button{
         background-color: $body-bg-d;
+        border: 1px solid $light-overlay-d;
+
+        &:hover,
+        &:hover:not(:disabled){
+            background-color: $light-drak-d;
+        }
+    }
+      
+    .emoji-button-highlighted{
+        background-color: $text-color-d;
+      
+        &:hover,
+        &:hover:not(:disabled){
+            background-color: $text-color-d;
+        }
     }
     .xblock.xmodule_display.xmodule_HtmlBlock .blue-text{color: $primary;}
 


### PR DESCRIPTION
This PR fixes the selected emojis not being highlighted in survey xblock issue as explained [here](https://github.com/openedx/wg-build-test-release/issues/471).