### PR TITLE
feat: improve readability of headings and list items in dark mode

### DIFF
--- a/changelog.d/20250519_144355_muhammad.labeeb_fix_color_contrast.md
+++ b/changelog.d/20250519_144355_muhammad.labeeb_fix_color_contrast.md
@@ -1,0 +1,1 @@
+- [Improvement] Change color of headings and list items in dark mode to improve readability. (by @mlabeeb03)

--- a/tutorindigo/templates/indigo/lms/static/sass/xblock/_xblock.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/xblock/_xblock.scss
@@ -476,6 +476,13 @@
         background-color: $body-bg-d;
     }
     .xblock.xmodule_display.xmodule_HtmlBlock .blue-text{color: $primary;}
+    .xblock.xmodule_display.xmodule_HtmlBlock ul li::marker,
+    .xblock.xmodule_display.xmodule_HtmlBlock ul li strong{
+        color: $text-color-d;
+    }
+    .xblock.xmodule_display.xmodule_HtmlBlock .course-structure h3{
+        color: $text-color-d;
+    }
 
 
     .edx-notes-wrapper{


### PR DESCRIPTION
closes #157
This PR fixes the issue mentioned in #157 and [here](https://github.com/openedx/wg-build-test-release/issues/460#issuecomment-2876223579).
Dark theme now uses white color for headings and list items to improve readability.
![Uploading Screenshot 2025-05-19 at 2.29.51 PM.png…]()

