### PR TITLE
fix: do not assign theme to preview pages

### DIFF
--- a/changelog.d/20250521_190157_danyal.faheem_remove_preview.md
+++ b/changelog.d/20250521_190157_danyal.faheem_remove_preview.md
@@ -1,0 +1,1 @@
+- [Improvement] Do not assign theme to preview site during initialization as the preview page has been migrated to the learning MFE. (by @Danyal-Faheem)

--- a/tutorindigo/templates/indigo/tasks/init.sh
+++ b/tutorindigo/templates/indigo/tasks/init.sh
@@ -12,6 +12,4 @@ assign_theme('{{ LMS_HOST }}')
 assign_theme('{{ LMS_HOST }}:8000')
 assign_theme('{{ CMS_HOST }}')
 assign_theme('{{ CMS_HOST }}:8001')
-assign_theme('{{ PREVIEW_LMS_HOST }}')
-assign_theme('{{ PREVIEW_LMS_HOST }}:8000')
 "


### PR DESCRIPTION
Original issue: https://github.com/overhangio/tutor/issues/1231
This PR is dependent on https://github.com/overhangio/tutor/pull/1238 to be merged first

This is because the preview page has been migrated to the learning MFE and do not run on a separate domain.