### PR TITLE
Revert "fix!: do not assign theme to preview pages (#162)"

### DIFF
--- a/tutorindigo/templates/indigo/tasks/init.sh
+++ b/tutorindigo/templates/indigo/tasks/init.sh
@@ -12,4 +12,6 @@ assign_theme('{{ LMS_HOST }}')
 assign_theme('{{ LMS_HOST }}:8000')
 assign_theme('{{ CMS_HOST }}')
 assign_theme('{{ CMS_HOST }}:8001')
+assign_theme('{{ PREVIEW_LMS_HOST }}')
+assign_theme('{{ PREVIEW_LMS_HOST }}:8000')
 "


### PR DESCRIPTION
This reverts commit 2fc37731054e7f5bb46040599b7b70302c197135.

We revert this commit as the upstream change was merged in the master branch and is not to be backported to teak. Therefore, the current builds running on top of teak are failing.