### PR TITLE
fix!: do not assign theme to preview pages

### DIFF
--- a/changelog.d/20250521_190157_danyal.faheem_remove_preview.md
+++ b/changelog.d/20250521_190157_danyal.faheem_remove_preview.md
@@ -1,0 +1,1 @@
+- 💥[Improvement] Do not assign theme to preview site during initialization as the preview page has been migrated to the learning MFE. (by @Danyal-Faheem)

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -78,7 +78,7 @@ with open(
 # Override openedx & mfe docker image names
 @hooks.Filters.CONFIG_DEFAULTS.add(priority=hooks.priorities.LOW)
 def _override_openedx_docker_image(
-    items: list[tuple[str, t.Any]]
+    items: list[tuple[str, t.Any]],
 ) -> list[tuple[str, t.Any]]:
     openedx_image = ""
     mfe_image = ""

--- a/tutorindigo/templates/indigo/tasks/init.sh
+++ b/tutorindigo/templates/indigo/tasks/init.sh
@@ -12,6 +12,4 @@ assign_theme('{{ LMS_HOST }}')
 assign_theme('{{ LMS_HOST }}:8000')
 assign_theme('{{ CMS_HOST }}')
 assign_theme('{{ CMS_HOST }}:8001')
-assign_theme('{{ PREVIEW_LMS_HOST }}')
-assign_theme('{{ PREVIEW_LMS_HOST }}:8000')
 "


### PR DESCRIPTION
This is because the preview page has been migrated to the learning MFE and do not run on a separate domain.

This PR was initially added in #162  and later reverted in #168 as the change was never meant to be added to the teak release but it had been rebased into the teak branch in tutor-indo. We now add it to the main branch to stay up to date with the master branch.