### PR TITLE
Zubair/tutor indigo accessibility fixes

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/sass/extra/_header.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/extra/_header.scss
@@ -1,9 +1,4 @@
 // Include custom header
-.nav-skip {
-    &:focus {
-        z-index: 9999;
-    }
-}
 header.global-header {
     border: none;
     padding: 0;

--- a/tutorindigo/templates/indigo/lms/templates/header/user_dropdown.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/user_dropdown.html
@@ -44,6 +44,6 @@ should_show_order_history = should_redirect_to_order_history_microfrontend() and
         % if should_show_order_history:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>
         % endif
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Logout")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
     </div>
 </div>


### PR DESCRIPTION
This update passes footer navigation links as props from the Indigo plugin to ensure consistent rendering of footer navigation across the platform.

This change supports the following PR:
https://github.com/edly-io/frontend-component-footer/pull/13

Related issue:
#146