### PR TITLE
fix: make 'skip to content' consistent

### DIFF
--- a/tutorindigo/templates/indigo/lms/static/sass/extra/_header.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/extra/_header.scss
@@ -1,9 +1,30 @@
 // Include custom header
-.nav-skip {
+body {
+  .nav-skip {
+
     &:focus {
-        z-index: 9999;
+      left: 50%;
+      position: absolute;
+      top: 5px;
+      height: auto;
+      background-color: $black;
+      margin: 0;
+      opacity: 0.8;
+      color: white;
+      text-decoration: none;
+      outline: none;
+      text-align: center;
+      width: auto;
+      font-size: 1rem;
+      line-height: 1.45;
+      padding: 0 5px;
+      transform: translateX(-50%);
+      z-index: 9999;
+      clip: auto;
     }
+  }
 }
+
 header.global-header {
     border: none;
     padding: 0;

--- a/tutorindigo/templates/indigo/lms/templates/courseware/course_about.html
+++ b/tutorindigo/templates/indigo/lms/templates/courseware/course_about.html
@@ -54,7 +54,7 @@ from openedx.core.lib.courses import course_image_url
 
 <%block name="pagetitle">${course.display_name_with_default}</%block>
 
-<section class="course-info about container">
+<section class="course-info about container" id="main">
 
   <%block name="course_about_header">
   <!-- Course profile header is updated inclusive of course heading and course image. -->

--- a/tutorindigo/templates/indigo/lms/templates/header/user_dropdown.html
+++ b/tutorindigo/templates/indigo/lms/templates/header/user_dropdown.html
@@ -44,6 +44,6 @@ should_show_order_history = not enterprise_customer_portal
         % if should_show_order_history:
             <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${settings.ORDER_HISTORY_MICROFRONTEND_URL}" role="menuitem">${_("Order History")}</a></div>
         % endif
-        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Logout")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
     </div>
 </div>


### PR DESCRIPTION
## Description
This PR makes the **"Skip to content"** link styling to ensure a consistent and accessible experience across all pages.  
The update applies unified SCSS rules for the `.sr-only-focusable` class within the `header` element, ensuring the link is:

- Positioned consistently at the top center of the page  
- Clearly visible on focus with high contrast (black background, white text)  
- Readable and easily accessible for keyboard users  


 
**Taiga Task (if you have access):**  
- [Skip to main content](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/43)
- [Consistent navigation](https://tree.taiga.io/project/zaraahmed-tutor-indigo-accessibility/us/81)

---

## Screenshots
| Before | After |
| :--- | :---: |
| <img width="1620" height="654" alt="image" src="https://github.com/user-attachments/assets/956cf99e-1ccc-4d95-a0ae-b50dd5749f59" /> | <img width="3022" height="596" alt="image" src="https://github.com/user-attachments/assets/900b9f80-98cc-4aad-93c0-067e43d67538" /> |
| <img width="3022" height="502" alt="image" src="https://github.com/user-attachments/assets/cc60f699-56f9-458d-acb4-4fd6cbb1576d" /> |  <img width="3022" height="514" alt="image" src="https://github.com/user-attachments/assets/3f5c598d-3293-4f76-b721-97837e8381f6" /> |
| <img width="3022" height="638" alt="image" src="https://github.com/user-attachments/assets/6c8958a6-77a7-41ab-ac18-9a57a42da3ca" /> | <img width="3022" height="676" alt="image" src="https://github.com/user-attachments/assets/9f8a5c71-1cdf-4288-bd25-568d378639ce" /> |