### PR TITLE
chore: redirect to tutor page on tutor logo click

### DIFF
--- a/changelog.d/20260119_145650_faraz.maqsood_redirect_to_tutor_page_instead_of_tutor_docs.md
+++ b/changelog.d/20260119_145650_faraz.maqsood_redirect_to_tutor_page_instead_of_tutor_docs.md
@@ -1,0 +1,1 @@
+- [Chore] Redirect to tutor page(https://edly.io/tutor/) instead of tutor docs(https://docs.tutor.edly.io) on tutor logo click in legacy pages footer. (by @Faraz32123)

--- a/tutorindigo/templates/indigo/lms/templates/footer.html
+++ b/tutorindigo/templates/indigo/lms/templates/footer.html
@@ -95,7 +95,7 @@
         <ul class="logo-list">
           <li>Powered by:</li>
           <li>
-            <a href="https://docs.tutor.edly.io" rel="noopener" target="_blank">
+            <a href="https://edly.io/tutor/" rel="noopener" target="_blank">
               <img src="${static.url('images/tutor-logo.png')}" alt="Runs on Tutor" width="80" />
             </a>
           </li>


### PR DESCRIPTION
Redirect to tutor page(https://edly.io/tutor/) instead of tutor docs(https://docs.tutor.edly.io) on tutor logo click in legacy pages footer.