### PR TITLE
chore: change indigo brand version

### DIFF
--- a/changelog.d/20260129_122214_faraz.maqsood_change_indigo_brand_version_that_ships_a_user_dropdown_icon_bugFix.md
+++ b/changelog.d/20260129_122214_faraz.maqsood_change_indigo_brand_version_that_ships_a_user_dropdown_icon_bugFix.md
@@ -1,0 +1,1 @@
+- [Chore] Change indigo brand version that ships a user dropdown icon bug fix. (by @Faraz32123)

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -120,7 +120,7 @@ for mfe in indigo_styled_mfes:
             (
                 f"mfe-dockerfile-post-npm-install-{mfe}",
                 """
-RUN npm install '@edx/brand@github:@edly-io/brand-openedx#ulmo/indigo'
+RUN npm install '@edx/brand@github:@edly-io/brand-openedx#indigo-2.4.3'
 """,  # noqa: E501
             ),
         ]
@@ -129,7 +129,7 @@ RUN npm install '@edx/brand@github:@edly-io/brand-openedx#ulmo/indigo'
 hooks.Filters.ENV_PATCHES.add_item(
     (
         "mfe-dockerfile-post-npm-install-authn",
-        "RUN npm install '@edx/brand@github:@edly-io/brand-openedx#ulmo/indigo'",
+        "RUN npm install '@edx/brand@github:@edly-io/brand-openedx#indigo-2.4.3'",
     )
 )
 


### PR DESCRIPTION
- Change indigo brand version to [indigo-2.4.3](https://github.com/edly-io/brand-openedx/releases/tag/indigo-2.4.3) that ships a user dropdown icon bug fix.
- close #194 