### PR TITLE
feat: Indigo updates for the Course Catalog MFE

### DIFF
--- a/tutorindigo/components/CatalogCourseCard.jsx
+++ b/tutorindigo/components/CatalogCourseCard.jsx
@@ -1,0 +1,90 @@
+
+const getFullImageUrl = (path) => {
+  if (!path) {
+    return '';
+  }
+  return `${getConfig().LMS_BASE_URL}${path}`;
+};
+
+const noCourseImg = `${getConfig().LMS_BASE_URL}/theming/asset/images/no_course_image.png`;
+const DATE_FORMAT_OPTIONS = { month: 'short', day: 'numeric', year: 'numeric' };
+
+const messages = {
+  startDate: {
+    id: 'generic.course-card.start-date',
+    defaultMessage: 'Starts: {startDate}',
+    description: 'Start date.',
+  }
+};
+
+const formatDate = (dateString, intl) => {
+  const date = new Date(dateString);
+  return intl.formatDate(date, DATE_FORMAT_OPTIONS);
+};
+
+const getStartDateDisplay = (courseData, intl) => {
+  if (courseData?.advertisedStart) {
+    return courseData.advertisedStart;
+  }
+
+  if (courseData?.start) {
+    return formatDate(courseData.start, intl);
+  }
+
+  return '';
+};
+
+const CourseCard = ({
+  isLoading,
+  courseId,
+  courseOrg,
+  courseName,
+  courseNumber,
+  courseImageUrl,
+  courseStartDate,
+  courseAdvertisedStart,
+}) => {
+  const intl = useIntl();
+  const isExtraSmall = useMediaQuery({ maxWidth: breakpoints.small.maxWidth });
+  const startDateDisplay = (courseStartDate || courseAdvertisedStart) ? getStartDateDisplay({
+    start: courseStartDate,
+    advertisedStart: courseAdvertisedStart,
+  }, intl) : null;
+
+  return (
+    <Card
+      className={`course-card d-flex ${isExtraSmall ? 'w-100' : 'course-card-desktop'}`}
+      isLoading={isLoading}
+      data-testid="course-card"
+    >
+      <Card.ImageCap
+        src={getFullImageUrl(courseImageUrl)}
+        fallbackSrc={noCourseImg}
+        srcAlt={`${courseName} ${courseNumber}`}
+        skeletonDuringImageLoad
+      />
+      <div className="px-4 py-2 text-left x-small">{courseNumber}</div>
+      <Card.Header
+        title={courseName}
+        subtitle={(
+          <div>{courseOrg}</div>
+        )}
+        size="sm"
+      />
+      <Card.Section />
+      {!isLoading && (
+        <Button
+          as={Link}
+          to={courseId ? `/courses/${courseId}/about` : undefined}
+          className="mx-4 mb-4"
+        >Learn More</Button>
+      )}
+      <Card.Footer className="justify-content-start py-3">
+        <Icon className="mr-2" src={Calendar} aria-label={intl.formatMessage(messages.startDate)} />
+        {startDateDisplay && intl.formatMessage(messages.startDate, {
+          startDate: startDateDisplay,
+        })}
+      </Card.Footer>
+    </Card>
+  );
+};

--- a/tutorindigo/components/Imports.jsx
+++ b/tutorindigo/components/Imports.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import Cookies from 'universal-cookie';
 
 import { getConfig } from '@edx/frontend-platform';
-import { Icon } from '@openedx/paragon';
-import { Nightlight, WbSunny } from '@openedx/paragon/icons';
+import {
+  breakpoints, Button, Card, Icon, useMediaQuery,
+} from '@openedx/paragon';
+import { Calendar, Nightlight, WbSunny } from '@openedx/paragon/icons';
 import { useIntl } from '@edx/frontend-platform/i18n';

--- a/tutorindigo/patches/mfe-env-config-runtime-definitions
+++ b/tutorindigo/patches/mfe-env-config-runtime-definitions
@@ -2,3 +2,4 @@
 {{- patch("MobileViewHeader.jsx") }}
 {{- patch("ThemedLogo.jsx") }}
 {{- patch("ToggleThemeButton.jsx") }}
+{{- patch("CatalogCourseCard.jsx") }}

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -347,3 +347,61 @@ def _add_themed_logo(
         )
 
     return mfes
+
+
+PLUGIN_SLOTS.add_items(
+    [
+        (
+            "catalog",
+            "org.openedx.frontend.catalog.home_page.course_card",
+            """
+        {
+            op: PLUGIN_OPERATIONS.Hide,
+            widgetId: 'default_contents',
+        }
+        """,
+        ),
+        (
+            "catalog",
+            "org.openedx.frontend.catalog.home_page.course_card",
+            """
+        {
+            op: PLUGIN_OPERATIONS.Insert,
+            widget: {
+                id: 'indigo-catalog-home-course-card',
+                type: DIRECT_PLUGIN,
+                RenderWidget: (props) => (
+                  <CourseCard {...props} />
+                ),
+            },
+        },
+        """,
+        ),
+        (
+            "catalog",
+            "org.openedx.frontend.catalog.course_catalog_page.data_table.course_card",
+            """
+        {
+            op: PLUGIN_OPERATIONS.Hide,
+            widgetId: 'default_contents',
+        }
+        """,
+        ),
+        (
+            "catalog",
+            "org.openedx.frontend.catalog.course_catalog_page.data_table.course_card",
+            """
+        {
+            op: PLUGIN_OPERATIONS.Insert,
+            widget: {
+                id: 'indigo-catalog-course-card',
+                type: DIRECT_PLUGIN,
+                RenderWidget: (props) => (
+                  <CourseCard {...props} />
+                ),
+            },
+        },
+        """,
+        ),
+    ]
+)


### PR DESCRIPTION
## Description

This PR introduces key enhancements to the **Course Catalog MFE** as part of the Indigo theme integration in the Tutor-Indigo plugin.

The update includes the addition of **plugin slots in the course card**, enabling greater extensibility and customization, along with a **new course card component** adapted to work seamlessly with Indigo’s design system.

These changes improve flexibility for operators to inject custom UI elements into course cards and ensure styling consistency with the Indigo theme across the catalog experience.

## Key Changes

- Added **course card plugin slots** to enable customization points within the Course Catalog MFE.
- Introduced a **new Course Card component** that:
  - Adheres to Indigo theme styles and tokens.
  - Serves as a central reusable component for course listings.
  - Provides structured places for plugin injection via slots.
- Ensured that the new course card component works consistently with the existing MFE layout and interaction patterns.
- Verified integration with the Indigo theme variables for color, typography, spacing, and responsiveness.


| Before | After |
|------|------|
| <img width="716" height="740" alt="image" src="https://github.com/user-attachments/assets/3ca87b76-b482-48db-8691-032c4cbb8094" /> | <img width="886" height="970" alt="image" src="https://github.com/user-attachments/assets/e4f6b3d2-38bd-4c15-a72d-8d0eb2d5cf68" /> |
