### PR TITLE
fix: Fix duplicate logo slot registration

### DIFF
--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -320,25 +320,40 @@ MFE_CONFIG["PARAGON_THEME_URLS"] = {json.dumps(paragon_theme_urls)}
 hooks.Filters.ENV_PATCHES.add_item(("mfe-lms-common-settings", fstring))
 
 
-for mfe in indigo_styled_mfes:
-    PLUGIN_SLOTS.add_item(
-        (
-            mfe,
-            "logo_slot",
-            """
-            {
-                op: PLUGIN_OPERATIONS.Hide,
-                widgetId: 'default_contents',
-            },
-            {
-                op: PLUGIN_OPERATIONS.Insert,
-                widget: {
-                    id: 'custom_logo',
-                    type: DIRECT_PLUGIN,
-                    RenderWidget: ThemedLogo,
+_REGISTERED_LOGO_SLOT_MFES: set[str] = set()
+
+@MFE_APPS.add()  # type: ignore
+def _add_themed_logo(
+    mfes: dict[str, MFE_ATTRS_TYPE],
+) -> dict[str, MFE_ATTRS_TYPE]:
+    for mfe in mfes:
+        mfe_name = str(mfe)
+
+        if mfe_name in _REGISTERED_LOGO_SLOT_MFES:
+            continue
+
+        PLUGIN_SLOTS.add_item(
+            (
+                mfe_name,
+                "logo_slot",
+                """
+                {
+                    op: PLUGIN_OPERATIONS.Hide,
+                    widgetId: 'default_contents',
+                },
+                {
+                    op: PLUGIN_OPERATIONS.Insert,
+                    widget: {
+                        id: 'custom_logo',
+                        type: DIRECT_PLUGIN,
+                        RenderWidget: ThemedLogo,
+                    }
                 }
-            }
-            """,
+                """,
+            )
         )
-    )
+
+        _REGISTERED_LOGO_SLOT_MFES.add(mfe_name)
+
+    return mfes
 

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -320,30 +320,25 @@ MFE_CONFIG["PARAGON_THEME_URLS"] = {json.dumps(paragon_theme_urls)}
 hooks.Filters.ENV_PATCHES.add_item(("mfe-lms-common-settings", fstring))
 
 
-@MFE_APPS.add()  # type: ignore
-def _add_themed_logo(
-    mfes: dict[str, MFE_ATTRS_TYPE],
-) -> dict[str, MFE_ATTRS_TYPE]:
-    for mfe in mfes:
-        PLUGIN_SLOTS.add_item(
-            (
-                str(mfe),
-                "logo_slot",
-                """
-                {
-                    op: PLUGIN_OPERATIONS.Hide,
-                    widgetId: 'default_contents',
-                },
-                {
-                    op: PLUGIN_OPERATIONS.Insert,
-                    widget: {
-                        id: 'custom_logo',
-                        type: DIRECT_PLUGIN,
-                        RenderWidget: ThemedLogo,
-                    }
+for mfe in indigo_styled_mfes:
+    PLUGIN_SLOTS.add_item(
+        (
+            mfe,
+            "logo_slot",
+            """
+            {
+                op: PLUGIN_OPERATIONS.Hide,
+                widgetId: 'default_contents',
+            },
+            {
+                op: PLUGIN_OPERATIONS.Insert,
+                widget: {
+                    id: 'custom_logo',
+                    type: DIRECT_PLUGIN,
+                    RenderWidget: ThemedLogo,
                 }
+            }
             """,
-            )
         )
+    )
 
-    return mfes


### PR DESCRIPTION
## Summary
Fix duplicate logo rendering across MFEs by keeping dynamic `logo_slot` registration via `@MFE_APPS.add()` while making the registration idempotent to ensure each MFE registers the `custom_logo` widget only once.

## Root cause
`PLUGIN_SLOTS.add_item()` for `logo_slot` was being called inside the `@MFE_APPS.add()` callback. Since that hook can be evaluated multiple times during initialization, the same `custom_logo` widget could be registered more than once for the same MFE, resulting in duplicate logos.

## Fix
Retain dynamic iteration over all MFEs using `@MFE_APPS.add()`, but add a safeguard to:
- Check if `logo_slot` is already registered for an MFE
- Skip registration if it already exists

This ensures:
- No duplicate widget insertion
- Compatibility with plugin-based and future MFEs
- Safe execution even if the hook runs multiple times

## Validation
- Reproduced the issue locally
- Verified duplicate logo rendering on learner-dashboard, learning, and authoring MFEs
- Confirmed the duplication is resolved after this change

## Screenshots

### After Fix

#### learner-dashboard
- Single logo rendered correctly
<img width="1005" height="203" alt="Screenshot 2026-04-03 at 1 06 57 PM" src="https://github.com/user-attachments/assets/476777e8-5a22-41ab-9f7c-0ab517ab9547" />

#### learning MFE
- Single logo rendered correctly
<img width="1299" height="203" alt="Screenshot 2026-04-03 at 1 05 01 PM" src="https://github.com/user-attachments/assets/9590a436-09ef-41ae-9a51-da975996950a" />

#### authoring MFE
- Single logo rendered correctly
<img width="994" height="155" alt="Screenshot 2026-04-03 at 4 46 38 PM" src="https://github.com/user-attachments/assets/d68910da-0cd0-43ee-8892-f98dda36b1ba" />

