### PR TITLE
feat: Update light theme switch background color to use primary color variable

### DIFF
--- a/changelog.d/20260406_light_theme_switch_bg_color.md
+++ b/changelog.d/20260406_light_theme_switch_bg_color.md
@@ -1,6 +1,1 @@
-# Changelog Entry
-
-## Update light theme switch background color
-
-- **type**: feature
-- **description**: Changed the `$light-theme-switch-bg-color` variable from a hardcoded hex color value to use `$primary` for better consistency with the theme's primary color. This ensures the theme toggle switch background aligns with the overall design system and supports dynamic color theming.
+- [Improvement] Changed the `$light-theme-switch-bg-color` variable from a hardcoded hex color value to use `$primary` for better consistency with the theme's primary color. (by @arbirali)

--- a/changelog.d/20260406_light_theme_switch_bg_color.md
+++ b/changelog.d/20260406_light_theme_switch_bg_color.md
@@ -1,0 +1,6 @@
+# Changelog Entry
+
+## Update light theme switch background color
+
+- **type**: feature
+- **description**: Changed the `$light-theme-switch-bg-color` variable from a hardcoded hex color value to use `$primary` for better consistency with the theme's primary color. This ensures the theme toggle switch background aligns with the overall design system and supports dynamic color theming.

--- a/tutorindigo/templates/indigo/lms/static/sass/extra/_header.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/extra/_header.scss
@@ -109,7 +109,7 @@ header.global-header {
                 margin: 12px 0;
                 &:after {
                     margin: 4px 0 0 4px;
-                    border: 2px solid #15376D;
+                    border: 2px solid $primary;
                     border-width: 2px 2px 0 0;
                     transform: rotate(135deg);
                     content: "";

--- a/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_variables.scss
+++ b/tutorindigo/templates/indigo/lms/static/sass/partials/lms/theme/_variables.scss
@@ -35,7 +35,7 @@ $btn-color-d: #112F6B;
 $body-bg-d: #0D0D0E;
 
 $instructor-input-border-color: $gray-lighter;
-$light-theme-switch-bg-color: #1D386A;
+$light-theme-switch-bg-color: $primary;
 $dark-theme-switch-bg-color: #717D8A;
 
 $warning-400: #ffe340;


### PR DESCRIPTION
## Description

Changed the $light-theme-switch-bg-color variable from a hardcoded hex color value to $primary for better consistency with the theme's primary color. This ensures the theme toggle switch background aligns with the overall design system and supports dynamic color theming.

| Before | After |
|-----|-----|
| <img width="630" height="512" alt="image" src="https://github.com/user-attachments/assets/141917d2-0360-484d-b089-1ef1ea0ced70" /> | <img width="586" height="536" alt="image" src="https://github.com/user-attachments/assets/ef3a6b31-4c12-4fc4-a8ca-881713cf1833" /> |