### PR TITLE
Chore: drop compatibility with Python 3.9 and ensure compatibility with Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,15 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.14"]
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           pip install .[dev]

--- a/changelog.d/20260413_python_version_upgrade.md
+++ b/changelog.d/20260413_python_version_upgrade.md
@@ -1,1 +1,1 @@
-- [Improvement] Drop Python 3.9 (EOL) support and add Python 3.13 and 3.14 compatibility. Minimum required Python version is now 3.10.
+- [Improvement] Drop Python 3.9 (EOL) support and add Python 3.13 and 3.14 compatibility. Minimum required Python version is now 3.10. (by @Syed-Ali-Abbas-568)

--- a/changelog.d/20260413_python_version_upgrade.md
+++ b/changelog.d/20260413_python_version_upgrade.md
@@ -1,0 +1,1 @@
+- [Improvement] Drop Python 3.9 (EOL) support and add Python 3.13 and 3.14 compatibility. Minimum required Python version is now 3.10.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "tutor-indigo"
 description = "Indigo theme plugin for Tutor"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 license = { text = "AGPLv3" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "Edly" }, { email = "hello@edly.io" }]
 maintainers = [
     { name = "Hammad Yousaf" }, { email = "hammad.yousaf@arbisoft.com" },
@@ -17,10 +17,11 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "tutor-mfe>=21.0.0,<22.0.0", 


### PR DESCRIPTION
- Drop Python 3.9 (EOL) support; bump requires-python to >=3.10
- Add Python 3.13 and 3.14 PyPI classifiers
- Update CI matrix from single Python 3.9 to 3.10 and 3.14
- Upgrade GitHub Actions: actions/checkout@v4, actions/setup-python@v5

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>