### PR TITLE
feat: use frontend-base compatibility layer

### DIFF
--- a/tutorindigo/components/AddDarkTheme.jsx
+++ b/tutorindigo/components/AddDarkTheme.jsx
@@ -1,5 +1,5 @@
 
-let themeVariant = 'selected-paragon-theme-variant';
+let themeVariant = 'selected-theme-variant';
 
 const AddDarkTheme = () => {
   const isThemeToggleEnabled = getConfig().INDIGO_ENABLE_DARK_TOGGLE;
@@ -40,7 +40,7 @@ const AddDarkTheme = () => {
     });
 
     if (isThemeToggleEnabled && theme === 'dark') {
-      document.documentElement.setAttribute('data-paragon-theme-variant', 'dark');
+      document.documentElement.setAttribute('data-theme-variant', 'dark');
 
       observer.observe(document.body, { childList: true, subtree: true });
       setTimeout(() => observer?.disconnect(), 15000); // clear after 15 sec to avoid resource usage

--- a/tutorindigo/components/MobileViewHeader.jsx
+++ b/tutorindigo/components/MobileViewHeader.jsx
@@ -19,10 +19,10 @@ const MobileViewHeader = () => {
           #root .logo-image.logo-white {
             display: none;
           }
-          [data-paragon-theme-variant="dark"] #root .logo-image {
+          [data-theme-variant="dark"] #root .logo-image {
             display: none;
           }
-          [data-paragon-theme-variant="dark"] #root .logo-white {
+          [data-theme-variant="dark"] #root .logo-white {
             display: block;
           }
         `}

--- a/tutorindigo/components/ThemedLogo.jsx
+++ b/tutorindigo/components/ThemedLogo.jsx
@@ -9,10 +9,10 @@ const ThemedLogo = () => {
           #root header .logo-image.logo-white {
             display: none;
           }
-          [data-paragon-theme-variant="dark"] #root header .logo-image {
+          [data-theme-variant="dark"] #root header .logo-image {
             display: none;
           }
-          [data-paragon-theme-variant="dark"] #root header .logo-white {
+          [data-theme-variant="dark"] #root header .logo-white {
             display: block;
           }
         `}

--- a/tutorindigo/components/ToggleThemeButton.jsx
+++ b/tutorindigo/components/ToggleThemeButton.jsx
@@ -3,7 +3,7 @@ const ToggleThemeButton = () => {
   const intl = useIntl();
   const [isDarkThemeEnabled, setIsDarkThemeEnabled] = useState(false);
 
-  const themeCookie = 'selected-paragon-theme-variant';
+  const themeCookie = 'selected-theme-variant';
   const themeCookieExpiry = 90; // days
   const isThemeToggleEnabled = getConfig().INDIGO_ENABLE_DARK_TOGGLE;
 
@@ -39,11 +39,11 @@ const ToggleThemeButton = () => {
     let theme = '';
 
     if (getCookie(themeCookie) === 'dark') {
-      document.documentElement.setAttribute('data-paragon-theme-variant', 'light');
+      document.documentElement.setAttribute('data-theme-variant', 'light');
       setIsDarkThemeEnabled(false);
       theme = 'light';
     } else {
-      document.documentElement.setAttribute('data-paragon-theme-variant', 'dark');
+      document.documentElement.setAttribute('data-theme-variant', 'dark');
       setIsDarkThemeEnabled(true);
       theme = 'dark';
     }

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -321,13 +321,13 @@ paragon_theme_urls = {
         "light": {
             "urls": {
                 "default": "https://raw.githubusercontent.com/edly-io/brand-openedx/refs/heads/ulmo/indigo/dist/light.min.css",
-                "brandOverride": "https://raw.githubusercontent.com/edly-io/brand-openedx/refs/heads/ulmo/indigo/dist/light.min.css",
+                "brandOverride": "https://cdn.jsdelivr.net/npm/@arbrandes/indigo-brand-openedx@2.6.0/dist/light.min.css",
             },
         },
         "dark": {
             "urls": {
                 "default": "https://raw.githubusercontent.com/edly-io/brand-openedx/refs/heads/ulmo/indigo/dist/dark.min.css",
-                "brandOverride": "https://raw.githubusercontent.com/edly-io/brand-openedx/refs/heads/ulmo/indigo/dist/dark.min.css",
+                "brandOverride": "https://cdn.jsdelivr.net/npm/@arbrandes/indigo-brand-openedx@2.6.0/dist/dark.min.css",
             }
         },
     }

--- a/tutorindigo/plugin.py
+++ b/tutorindigo/plugin.py
@@ -9,7 +9,7 @@ from glob import glob
 import importlib_resources
 from tutor import hooks
 from tutor.__about__ import __version_suffix__
-from tutormfe.hooks import MFE_APPS, MFE_ATTRS_TYPE, PLUGIN_SLOTS
+from tutormfe.hooks import FRONTEND_COMPAT_SLOTS, MFE_APPS, MFE_ATTRS_TYPE, PLUGIN_SLOTS
 
 from .__about__ import __version__
 
@@ -122,7 +122,7 @@ for mfe in indigo_styled_mfes:
             (
                 f"mfe-dockerfile-post-npm-install-{mfe}",
                 """
-RUN npm install '@edx/brand@github:@edly-io/brand-openedx#indigo-2.5.2'
+RUN npm install '@edx/brand@npm:@arbrandes/indigo-brand-openedx@^2.6.0'
 """,  # noqa: E501
             ),
         ]
@@ -131,7 +131,14 @@ RUN npm install '@edx/brand@github:@edly-io/brand-openedx#indigo-2.5.2'
 hooks.Filters.ENV_PATCHES.add_item(
     (
         "mfe-dockerfile-post-npm-install-authn",
-        "RUN npm install '@edx/brand@github:@edly-io/brand-openedx#indigo-2.5.2'",
+        "RUN npm install '@edx/brand@npm:@arbrandes/indigo-brand-openedx@^2.6.0'",
+    )
+)
+
+hooks.Filters.ENV_PATCHES.add_item(
+    (
+        "mfe-dockerfile-pre-npm-install-site",
+        "RUN npm pkg set 'dependencies.@edx/brand=npm:@arbrandes/indigo-brand-openedx@^2.6.0'",  # noqa: E501
     )
 )
 
@@ -188,83 +195,96 @@ for path in itertools.chain(
         hooks.Filters.ENV_PATCHES.add_item((os.path.basename(path), patch_file.read()))
 
 
+INDIGO_FOOTER_SLOT = (
+    "org.openedx.frontend.layout.footer.v1",
+    """
+    {
+        op: PLUGIN_OPERATIONS.Hide,
+        widgetId: 'default_contents',
+    },
+    {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+            id: 'indigo_footer',
+            type: DIRECT_PLUGIN,
+            priority: 1,
+            RenderWidget: IndigoFooter,
+        },
+    },
+    {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+            id: 'read_theme_cookie',
+            type: DIRECT_PLUGIN,
+            priority: 2,
+            RenderWidget: AddDarkTheme,
+        },
+    },
+""",
+)
+
+INDIGO_DESKTOP_SECONDARY_MENU_SLOT = (
+    "desktop_secondary_menu_slot",
+    """
+    {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+            id: 'theme_switch_button',
+            type: DIRECT_PLUGIN,
+            RenderWidget: ToggleThemeButton,
+        },
+    },
+""",
+)
+
+# Hide the default mobile header (it only shows the logo) and replace it.
+INDIGO_MOBILE_HEADER_SLOT = (
+    "mobile_header_slot",
+    """
+    {
+        op: PLUGIN_OPERATIONS.Hide,
+        widgetId: 'default_contents',
+    },
+    {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+            id: 'theme_switch_button',
+            type: DIRECT_PLUGIN,
+            RenderWidget: MobileViewHeader,
+        },
+    },
+""",
+)
+
+INDIGO_LOGO_SLOT = (
+    "logo_slot",
+    """
+    {
+        op: PLUGIN_OPERATIONS.Hide,
+        widgetId: 'default_contents',
+    },
+    {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+            id: 'custom_logo',
+            type: DIRECT_PLUGIN,
+            RenderWidget: ThemedLogo,
+        }
+    }
+""",
+)
+
+# Frontend-base site compatibility
+FRONTEND_COMPAT_SLOTS.add_item(("all", *INDIGO_FOOTER_SLOT))
+FRONTEND_COMPAT_SLOTS.add_item(("all", *INDIGO_DESKTOP_SECONDARY_MENU_SLOT))
+FRONTEND_COMPAT_SLOTS.add_item(("all", *INDIGO_MOBILE_HEADER_SLOT))
+FRONTEND_COMPAT_SLOTS.add_item(("all", *INDIGO_LOGO_SLOT))
+
 for mfe in indigo_styled_mfes:
-    PLUGIN_SLOTS.add_item(
-        (
-            mfe,
-            "org.openedx.frontend.layout.footer.v1",
-            """
-            {
-                op: PLUGIN_OPERATIONS.Hide,
-                widgetId: 'default_contents',
-            },
-            {
-                op: PLUGIN_OPERATIONS.Insert,
-                widget: {
-                    id: 'indigo_footer',
-                    type: DIRECT_PLUGIN,
-                    priority: 1,
-                    RenderWidget: IndigoFooter,
-                },
-            },
-            {
-                op: PLUGIN_OPERATIONS.Insert,
-                widget: {
-                    id: 'read_theme_cookie',
-                    type: DIRECT_PLUGIN,
-                    priority: 2,
-                    RenderWidget: AddDarkTheme,
-                },
-            },
-  """,
-        ),
-    )
+    PLUGIN_SLOTS.add_item((mfe, *INDIGO_FOOTER_SLOT))
     if mfe != "learning":
-        PLUGIN_SLOTS.add_item(
-            (
-                mfe,
-                "desktop_secondary_menu_slot",
-                """
-                {
-                    op: PLUGIN_OPERATIONS.Insert,
-                    widget: {
-                        id: 'theme_switch_button',
-                        type: DIRECT_PLUGIN,
-                        RenderWidget: ToggleThemeButton,
-                    },
-                },
-        """,
-            )
-        )
-        PLUGIN_SLOTS.add_items(
-            [
-                (
-                    # Hide the default mobile header as it only shows logo
-                    mfe,
-                    "mobile_header_slot",
-                    """
-                {
-                    op: PLUGIN_OPERATIONS.Hide,
-                    widgetId: 'default_contents',
-                }
-                """,
-                ),
-                (
-                    mfe,
-                    "mobile_header_slot",
-                    """
-                {
-                    op: PLUGIN_OPERATIONS.Insert,
-                    widget: {
-                        id: 'theme_switch_button',
-                        type: DIRECT_PLUGIN,
-                        RenderWidget: MobileViewHeader,
-                    },
-                },
-                """,
-                ),
-            ]
-        )
+        PLUGIN_SLOTS.add_item((mfe, *INDIGO_DESKTOP_SECONDARY_MENU_SLOT))
+        PLUGIN_SLOTS.add_item((mfe, *INDIGO_MOBILE_HEADER_SLOT))
 
 PLUGIN_SLOTS.add_items(
     [
@@ -325,25 +345,6 @@ def _add_themed_logo(
     mfes: dict[str, MFE_ATTRS_TYPE],
 ) -> dict[str, MFE_ATTRS_TYPE]:
     for mfe in mfes:
-        PLUGIN_SLOTS.add_item(
-            (
-                str(mfe),
-                "logo_slot",
-                """
-                {
-                    op: PLUGIN_OPERATIONS.Hide,
-                    widgetId: 'default_contents',
-                },
-                {
-                    op: PLUGIN_OPERATIONS.Insert,
-                    widget: {
-                        id: 'custom_logo',
-                        type: DIRECT_PLUGIN,
-                        RenderWidget: ThemedLogo,
-                    }
-                }
-            """,
-            )
-        )
+        PLUGIN_SLOTS.add_item((str(mfe), *INDIGO_LOGO_SLOT))
 
     return mfes

--- a/tutorindigo/templates/indigo/lms/static/js/dark-theme.js
+++ b/tutorindigo/templates/indigo/lms/static/js/dark-theme.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
     'use strict';
 
-    const themeCookie = 'selected-paragon-theme-variant';
+    const themeCookie = 'selected-theme-variant';
 
     function applyThemeOnPage(){
       const theme = $.cookie(themeCookie);


### PR DESCRIPTION
### Description

Extracts each Indigo plugin slot configuration into a single `(slot_name, jsx)` tuple constant and deduplicates the per-MFE `PLUGIN_SLOTS` entries by splatting those constants. The same constants are then registered with `FRONTEND_COMPAT_SLOTS` so the Indigo footer, theme switch buttons, mobile header, and themed logo also apply when running under frontend-base.

This depends on https://github.com/overhangio/tutor-mfe/pull/298.

### LLM usage notice

Built with assistance from Claude.