### PR TITLE
fix: deduplicate custom_logo insert in logo_slot at runtime

### DIFF
--- a/changelog.d/20260513_000000_ahmed_arb_dedupe_custom_logo.md
+++ b/changelog.d/20260513_000000_ahmed_arb_dedupe_custom_logo.md
@@ -1,0 +1,1 @@
+- [Bugfix] Deduplicate `custom_logo` insert plugins in `logo_slot` at runtime to prevent multiple logos rendering when more than one insert operation is registered. (by @ahmed-arb)

--- a/tutorindigo/patches/mfe-env-config-runtime-final
+++ b/tutorindigo/patches/mfe-env-config-runtime-final
@@ -1,4 +1,23 @@
 
+if (config.pluginSlots && config.pluginSlots['logo_slot']) {
+  config.pluginSlots['logo_slot'].keepDefault = false;
+
+  const logoInsertPlugins =
+    config.pluginSlots['logo_slot'].plugins.filter(plugin => plugin.op === 'insert' && plugin.widget?.id === 'custom_logo');
+
+  if (logoInsertPlugins.length > 1) {
+    let kept = false;
+    config.pluginSlots['logo_slot'].plugins =
+      config.pluginSlots['logo_slot'].plugins.filter(plugin => {
+        if (plugin.op === 'insert' && plugin.widget?.id === 'custom_logo') {
+          if (kept) return false;
+          kept = true;
+        }
+        return true;
+      });
+  }
+}
+
 if (config.pluginSlots && config.pluginSlots['org.openedx.frontend.layout.footer.v1']) {
   const footerPluginsToInsert =
     config.pluginSlots['org.openedx.frontend.layout.footer.v1'].plugins.filter(plugin => plugin.op === 'insert');


### PR DESCRIPTION
## Summary
- When multiple `insert` operations target `logo_slot` with the `custom_logo` widget, MFEs render duplicate logos. This patch dedupes those inserts at runtime so only the first `custom_logo` insert survives.
- Also sets `keepDefault = false` on `logo_slot` so the default logo content is suppressed when the slot is configured.

## Test plan
- [ ] Configure a deployment where `logo_slot` ends up with more than one `custom_logo` insert plugin (e.g. multiple plugins/slots stacking).
- [ ] Verify only one logo renders in MFE headers and no duplicates appear.
- [ ] Confirm single-insert deployments still render the expected logo unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)