### PR TITLE
fix: apply primary color to activation email

### DIFF
--- a/changelog.d/20260519_134347_faraz.maqsood_apply_primary_color_to_activation_email_as_well.md
+++ b/changelog.d/20260519_134347_faraz.maqsood_apply_primary_color_to_activation_email_as_well.md
@@ -1,0 +1,1 @@
+- [BugFix] Apply primary color to activation email button & heading. (by @Faraz32123)

--- a/tutorindigo/patches/openedx-lms-common-settings
+++ b/tutorindigo/patches/openedx-lms-common-settings
@@ -1,0 +1,4 @@
+# Prepend the indigo theme templates dir so it overrides app-directories templates
+# (e.g. ace_common, common/templates) which are otherwise found first by the app
+# directories loader before the comprehensive theme loader gets a chance.
+TEMPLATES[0]["DIRS"].insert(0, "/openedx/themes/indigo/lms/templates")

--- a/tutorindigo/templates/indigo/lms/templates/ace_common/edx_ace/common/return_to_course_cta.html
+++ b/tutorindigo/templates/indigo/lms/templates/ace_common/edx_ace/common/return_to_course_cta.html
@@ -1,0 +1,34 @@
+{% raw %}{% load i18n %}
+{% load ace %}
+
+<p>
+    {# email client support for style sheets is pretty spotty, so we have to inline all of these styles #}
+    <a
+    {% if reset_url %}
+        href={{reset_url}}
+    {% elif course_cta_url %}
+        href="{% with_link_tracking course_cta_url %}"
+    {% else %}
+        {%if course_ids|length > 1 %}
+            href="{% with_link_tracking dashboard_url %}"
+        {% else %}
+            href="{% with_link_tracking course_url %}"
+        {% endif %}
+    {% endif %}
+    style="
+        color: #ffffff;
+        text-decoration: none;
+        border-radius: 4px;
+        -webkit-border-radius: 4px;
+        -moz-border-radius: 4px;
+        background-color: {% endraw %}{{ INDIGO_PRIMARY_COLOR }}{% raw %};
+        border-top: 12px solid {% endraw %}{{ INDIGO_PRIMARY_COLOR }}{% raw %};
+        border-bottom: 12px solid {% endraw %}{{ INDIGO_PRIMARY_COLOR }}{% raw %};
+        border-right: 50px solid {% endraw %}{{ INDIGO_PRIMARY_COLOR }}{% raw %};
+        border-left: 50px solid {% endraw %}{{ INDIGO_PRIMARY_COLOR }}{% raw %};
+        display: inline-block;
+    ">
+        {# old email clients require the use of the font tag :( #}
+        <font color="#ffffff"><b>{{ course_cta_text }}</b></font>
+    </a>
+</p>{% endraw %}

--- a/tutorindigo/templates/indigo/lms/templates/student/edx_ace/accountactivation/email/body.html
+++ b/tutorindigo/templates/indigo/lms/templates/student/edx_ace/accountactivation/email/body.html
@@ -1,0 +1,71 @@
+{% raw %}{% extends 'ace_common/edx_ace/common/base_body.html' %}
+
+{% load django_markup %}
+{% load i18n %}
+{% load static %}
+{% block content %}
+<table width="100%" align="left" border="0" cellpadding="0" cellspacing="0" role="presentation">
+{% if route_enabled %}
+    <tr>
+        <td>
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                    {% blocktrans %}This is a routed Account Activation email for {{ routed_user }} ({{ routed_user_email }}): {{ routed_profile_name }}{% endblocktrans %}
+                {% endfilter %}
+                <br />
+            </p>
+        </td>
+    </tr>
+{% endif %}
+    <tr>
+        <td>
+            <h1 style="color: {% endraw %}{{ INDIGO_PRIMARY_COLOR }}{% raw %};">
+                {% trans "Account activation" as header_msg %}{{ header_msg | force_escape }}
+            </h1>
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                    {% blocktrans %}You're almost there! Use the link below to activate your account to access engaging, high-quality {{ platform_name }} courses. Note that you will not be able to log back into your account until you have activated it.{% endblocktrans %}
+                {% endfilter %}
+                <br />
+            </p>
+
+            {% filter force_escape %}
+                {% blocktrans asvar course_cta_text %}Activate your account{% endblocktrans %}
+            {% endfilter %}
+            {% include "ace_common/edx_ace/common/return_to_course_cta.html" with course_cta_text=course_cta_text course_cta_url=confirm_activation_link %}
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                    {% blocktrans %}Enjoy learning with {{ platform_name }}.{% endblocktrans %}
+                {% endfilter %}
+                <br />
+            </p>
+        </td>
+    </tr>
+        <td>
+            <p style="color: rgba(0,0,0,.75);">
+                {% blocktrans trimmed asvar assist_msg %}
+                If you need help, please use our web form at {start_anchor_web}{{ support_url }}{end_anchor} or email {start_anchor_email}{{ support_email }}{end_anchor}.
+                {% endblocktrans %}
+                {% interpolate_html assist_msg start_anchor_web='<a href="'|add:support_url|add:'">'|safe start_anchor_email='<a href="mailto:'|add:support_email|add:'">'|safe end_anchor='</a>'|safe %}
+                <br />
+            </p>
+        </td>
+    <tr>
+
+    </tr>
+    <tr>
+        <td>
+            <p style="color: rgba(0,0,0,.75);">
+                {% filter force_escape %}
+                    {% blocktrans %}This email message was automatically sent by {{ lms_url }} because someone attempted to create an account on {{ platform_name }} using this email address.{% endblocktrans %}
+                {% endfilter %}
+                <br />
+            </p>
+        </td>
+    </tr>
+</table>
+{% endblock %}{% endraw %}


### PR DESCRIPTION
close #100.
**Before:**
<img width="596" height="402" alt="Screenshot 2026-05-19 at 1 24 00 PM" src="https://github.com/user-attachments/assets/959a37f7-3049-4401-855c-1aa3a6dfc78f" />


**After:**
<img width="596" height="402" alt="Screenshot 2026-05-19 at 1 24 09 PM" src="https://github.com/user-attachments/assets/6d68089a-ae17-4b58-aca6-20af658a472b" />
