### PR TITLE
chore: remove changelog fragments already collected in v22.0.0

### DIFF
--- a/changelog.d/20260413_python_version_upgrade.md
+++ b/changelog.d/20260413_python_version_upgrade.md
@@ -1,1 +1,0 @@
-- 💥[Improvement] Add Python 3.13 and 3.14 support. Drop Python 3.9 (end-of-life). Update CI matrix from Python 3.9/3.12 to 3.10/3.14. (by @Syed-Ali-Abbas-568)

--- a/changelog.d/20260513_frontend_base_compat.md
+++ b/changelog.d/20260513_frontend_base_compat.md
@@ -1,1 +1,0 @@
-- [Feature] Updated Indigo theme integration for `frontend-base` to use runtime theme configuration through `PARAGON_THEME_URLS`, enabling consistent MFE branding without rebuilds. (by @arbirali)


### PR DESCRIPTION
`main` and `release` currently differ by exactly two files:

```
changelog.d/20260413_python_version_upgrade.md
changelog.d/20260513_frontend_base_compat.md
```

Both entries are already published in the `v22.0.0` section of `CHANGELOG.md`, on both branches, so `main` lists them twice: once collected, once still pending.

The Verawood upgrade (#215) was opened against `release`, where these two fragments had never existed (they came from #214 and #220, which landed on `main` only). `scriv collect` therefore had nothing to delete, and the entries were written straight into the `v22.0.0` section. When `deploy:main` merged `release` into `main`, main picked up that section while keeping its own fragment files.

Deleting the two fragments makes the `main` and `release` trees identical again:

```
$ git diff --stat release HEAD
$
```

No changelog entry, since this only corrects changelog bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)